### PR TITLE
DI auto-registration scanner using Scrutor

### DIFF
--- a/src/TripsTracker.Tools/Registration/ServiceRegistrationExtensions.cs
+++ b/src/TripsTracker.Tools/Registration/ServiceRegistrationExtensions.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TripsTracker.Tools.Registration;
+
+/// <summary>
+/// Provides auto-registration of application services using Scrutor assembly scanning.
+/// Registers all custom classes that implement an interface, excluding framework types.
+/// </summary>
+public static class ServiceRegistrationExtensions
+{
+    private static readonly string[] _applicationAssemblyPrefixes =
+    [
+        "TripsTracker."
+    ];
+
+    /// <summary>
+    /// Scans the specified assemblies and registers all application classes
+    /// that implement an interface, using the specified lifetime.
+    /// Only classes whose assembly name starts with the application prefix are registered.
+    /// </summary>
+    public static IServiceCollection AddApplicationServices(
+        this IServiceCollection services,
+        ServiceLifetime lifetime = ServiceLifetime.Scoped,
+        params string[] assemblyPrefixes)
+    {
+        var prefixes = assemblyPrefixes.Length > 0 ? assemblyPrefixes : _applicationAssemblyPrefixes;
+
+        services.Scan(scan => scan
+            .FromApplicationDependencies(a => prefixes.Any(p => a.GetName().Name?.StartsWith(p) == true))
+            .AddClasses(classes => classes
+                .Where(type => !type.IsAbstract && !type.IsGenericTypeDefinition))
+            .UsingRegistrationStrategy(Scrutor.RegistrationStrategy.Skip)
+            .AsImplementedInterfaces()
+            .WithLifetime(lifetime));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers application services with scoped lifetime (default for DbContext-dependent services).
+    /// </summary>
+    public static IServiceCollection AddScopedApplicationServices(
+        this IServiceCollection services,
+        params string[] assemblyPrefixes)
+        => services.AddApplicationServices(ServiceLifetime.Scoped, assemblyPrefixes);
+
+    /// <summary>
+    /// Registers application services with transient lifetime.
+    /// </summary>
+    public static IServiceCollection AddTransientApplicationServices(
+        this IServiceCollection services,
+        params string[] assemblyPrefixes)
+        => services.AddApplicationServices(ServiceLifetime.Transient, assemblyPrefixes);
+}

--- a/src/TripsTracker.Tools/TripsTracker.Tools.csproj
+++ b/src/TripsTracker.Tools/TripsTracker.Tools.csproj
@@ -4,6 +4,11 @@
     <ProjectReference Include="..\TripsTracker.Interfaces\TripsTracker.Interfaces.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/TripsTracker.Tests/Registration/ServiceRegistrationExtensionsTests.cs
+++ b/tests/TripsTracker.Tests/Registration/ServiceRegistrationExtensionsTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TripsTracker.Tools.Registration;
+
+namespace TripsTracker.Tests.Registration;
+
+[TestClass]
+public class ServiceRegistrationExtensionsTests
+{
+    #region Test Helpers
+
+    private interface ITestService { }
+    private class TestService : ITestService { }
+
+    private interface IIgnoredService { }
+
+    #endregion
+
+    #region AddApplicationServices
+
+    [TestMethod]
+    public void AddApplicationServices_RunsWithoutErrorsWhenNoClassesFound()
+    {
+        // Verifies the scanner handles empty assemblies gracefully
+        var services = new ServiceCollection();
+
+        var act = () => services.AddApplicationServices(ServiceLifetime.Scoped, "TripsTracker.");
+
+        // Should not throw
+        act();
+        var provider = services.BuildServiceProvider();
+        Assert.IsNotNull(provider);
+    }
+
+    [TestMethod]
+    public void AddApplicationServices_DoesNotRegisterFrameworkTypes()
+    {
+        var services = new ServiceCollection();
+        services.AddApplicationServices(ServiceLifetime.Scoped, "TripsTracker.");
+
+        // No Microsoft or System types should be registered by the scanner
+        var frameworkServices = services.Where(s =>
+            (s.ImplementationType?.Namespace?.StartsWith("Microsoft") == true) ||
+            (s.ImplementationType?.Namespace?.StartsWith("System") == true));
+
+        Assert.IsFalse(frameworkServices.Any(),
+            "Framework types should not be registered by the application scanner.");
+    }
+
+    [TestMethod]
+    public void AddApplicationServices_DefaultLifetimeIsScoped()
+    {
+        var services = new ServiceCollection();
+        services.AddApplicationServices(assemblyPrefixes: "TripsTracker.");
+
+        var appServices = services.Where(s =>
+            s.ImplementationType?.Assembly.GetName().Name?.StartsWith("TripsTracker.") == true);
+
+        foreach (var service in appServices)
+        {
+            Assert.AreEqual(ServiceLifetime.Scoped, service.Lifetime,
+                $"Service {service.ServiceType.Name} should have Scoped lifetime by default.");
+        }
+    }
+
+    [TestMethod]
+    public void AddScopedApplicationServices_RegistersWithScopedLifetime()
+    {
+        var services = new ServiceCollection();
+        services.AddScopedApplicationServices("TripsTracker.");
+
+        var appServices = services.Where(s =>
+            s.ImplementationType?.Assembly.GetName().Name?.StartsWith("TripsTracker.") == true);
+
+        foreach (var service in appServices)
+        {
+            Assert.AreEqual(ServiceLifetime.Scoped, service.Lifetime,
+                $"Service {service.ServiceType.Name} should have Scoped lifetime.");
+        }
+    }
+
+    [TestMethod]
+    public void AddTransientApplicationServices_RegistersWithTransientLifetime()
+    {
+        var services = new ServiceCollection();
+        services.AddTransientApplicationServices("TripsTracker.");
+
+        var appServices = services.Where(s =>
+            s.ImplementationType?.Assembly.GetName().Name?.StartsWith("TripsTracker.") == true);
+
+        foreach (var service in appServices)
+        {
+            Assert.AreEqual(ServiceLifetime.Transient, service.Lifetime,
+                $"Service {service.ServiceType.Name} should have Transient lifetime.");
+        }
+    }
+
+    [TestMethod]
+    public void AddApplicationServices_SkipsDuplicateRegistrations()
+    {
+        var services = new ServiceCollection();
+
+        // Register twice — should not throw or duplicate
+        services.AddApplicationServices(ServiceLifetime.Scoped, "TripsTracker.");
+        services.AddApplicationServices(ServiceLifetime.Scoped, "TripsTracker.");
+
+        // Should build without errors
+        var provider = services.BuildServiceProvider();
+        Assert.IsNotNull(provider);
+    }
+
+    #endregion
+}

--- a/tests/TripsTracker.Tests/TripsTracker.Tests.csproj
+++ b/tests/TripsTracker.Tests/TripsTracker.Tests.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest" Version="4.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Adds `ServiceRegistrationExtensions` in Tools project
- Scans application assemblies and registers all custom classes against their interfaces
- Skips framework/Microsoft/System types automatically
- Supports configurable assembly prefix filtering and lifetime selection
- 6 MSTests passing

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)