### PR TITLE
Configure host.json logging and IOptions pattern

### DIFF
--- a/src/TripsTracker.Functions/Program.cs
+++ b/src/TripsTracker.Functions/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using TripsTracker.Tools.Registration;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
@@ -10,5 +11,11 @@ builder.ConfigureFunctionsWebApplication();
 builder.Services
     .AddApplicationInsightsTelemetryWorkerService()
     .ConfigureFunctionsApplicationInsights();
+
+// Register strongly-typed configuration options
+builder.Services.AddApplicationOptions(builder.Configuration);
+
+// Auto-register all application services against their interfaces
+builder.Services.AddScopedApplicationServices("TripsTracker.");
 
 builder.Build().Run();

--- a/src/TripsTracker.Functions/host.json
+++ b/src/TripsTracker.Functions/host.json
@@ -1,10 +1,14 @@
 {
     "version": "2.0",
     "logging": {
+        "logLevel": {
+            "default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        },
         "applicationInsights": {
             "samplingSettings": {
-                "isEnabled": true,
-                "excludedTypes": "Request"
+                "isEnabled": false
             },
             "enableLiveMetricsFilters": true
         }

--- a/src/TripsTracker.Interfaces/Configuration/ApplicationInsightsOptions.cs
+++ b/src/TripsTracker.Interfaces/Configuration/ApplicationInsightsOptions.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TripsTracker.Interfaces.Configuration;
+
+/// <summary>
+/// Configuration options for Application Insights.
+/// Bound from the "ApplicationInsights" section in application settings.
+/// </summary>
+public class ApplicationInsightsOptions
+{
+    public const string SectionName = "ApplicationInsights";
+
+    [Required]
+    public string ConnectionString { get; set; } = string.Empty;
+}

--- a/src/TripsTracker.Interfaces/Configuration/DatabaseOptions.cs
+++ b/src/TripsTracker.Interfaces/Configuration/DatabaseOptions.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TripsTracker.Interfaces.Configuration;
+
+/// <summary>
+/// Configuration options for the database connection.
+/// Bound from the "Database" section in application settings.
+/// </summary>
+public class DatabaseOptions
+{
+    public const string SectionName = "Database";
+
+    [Required]
+    public string ConnectionString { get; set; } = string.Empty;
+}

--- a/src/TripsTracker.Interfaces/TripsTracker.Interfaces.csproj
+++ b/src/TripsTracker.Interfaces/TripsTracker.Interfaces.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\TripsTracker.Domain\TripsTracker.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TripsTracker.Tools/Registration/OptionsRegistrationExtensions.cs
+++ b/src/TripsTracker.Tools/Registration/OptionsRegistrationExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TripsTracker.Interfaces.Configuration;
+
+namespace TripsTracker.Tools.Registration;
+
+/// <summary>
+/// Registers strongly-typed IOptions configuration classes using the IOptions pattern.
+/// </summary>
+public static class OptionsRegistrationExtensions
+{
+    /// <summary>
+    /// Registers all application configuration options with validation on startup.
+    /// </summary>
+    public static IServiceCollection AddApplicationOptions(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services
+            .AddOptions<DatabaseOptions>()
+            .Bind(configuration.GetSection(DatabaseOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services
+            .AddOptions<ApplicationInsightsOptions>()
+            .Bind(configuration.GetSection(ApplicationInsightsOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        return services;
+    }
+}

--- a/src/TripsTracker.Tools/TripsTracker.Tools.csproj
+++ b/src/TripsTracker.Tools/TripsTracker.Tools.csproj
@@ -5,7 +5,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.5" />
     <PackageReference Include="Scrutor" Version="7.0.0" />
   </ItemGroup>
 

--- a/tests/TripsTracker.Tests/Configuration/OptionsRegistrationTests.cs
+++ b/tests/TripsTracker.Tests/Configuration/OptionsRegistrationTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TripsTracker.Interfaces.Configuration;
+using TripsTracker.Tools.Registration;
+
+namespace TripsTracker.Tests.Configuration;
+
+[TestClass]
+public class OptionsRegistrationTests
+{
+    #region Helpers
+
+    private static IServiceProvider BuildProviderWithConfig(Dictionary<string, string?> values)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddApplicationOptions(config);
+        return services.BuildServiceProvider();
+    }
+
+    #endregion
+
+    #region DatabaseOptions
+
+    [TestMethod]
+    public void DatabaseOptions_BindsConnectionStringFromConfiguration()
+    {
+        var provider = BuildProviderWithConfig(new()
+        {
+            [$"{DatabaseOptions.SectionName}:ConnectionString"] = "Server=test;Database=db;"
+        });
+
+        var options = provider.GetRequiredService<IOptions<DatabaseOptions>>().Value;
+
+        Assert.AreEqual("Server=test;Database=db;", options.ConnectionString);
+    }
+
+    [TestMethod]
+    public void DatabaseOptions_IsRegisteredAsIOptions()
+    {
+        var provider = BuildProviderWithConfig(new()
+        {
+            [$"{DatabaseOptions.SectionName}:ConnectionString"] = "Server=test;"
+        });
+
+        var options = provider.GetService<IOptions<DatabaseOptions>>();
+
+        Assert.IsNotNull(options);
+    }
+
+    #endregion
+
+    #region ApplicationInsightsOptions
+
+    [TestMethod]
+    public void ApplicationInsightsOptions_BindsConnectionStringFromConfiguration()
+    {
+        var provider = BuildProviderWithConfig(new()
+        {
+            [$"{ApplicationInsightsOptions.SectionName}:ConnectionString"] = "InstrumentationKey=test;"
+        });
+
+        var options = provider.GetRequiredService<IOptions<ApplicationInsightsOptions>>().Value;
+
+        Assert.AreEqual("InstrumentationKey=test;", options.ConnectionString);
+    }
+
+    [TestMethod]
+    public void ApplicationInsightsOptions_IsRegisteredAsIOptions()
+    {
+        var provider = BuildProviderWithConfig(new()
+        {
+            [$"{ApplicationInsightsOptions.SectionName}:ConnectionString"] = "InstrumentationKey=test;"
+        });
+
+        var options = provider.GetService<IOptions<ApplicationInsightsOptions>>();
+
+        Assert.IsNotNull(options);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- host.json: Information log level, Application Insights adaptive sampling disabled
- `DatabaseOptions` and `ApplicationInsightsOptions` in Interfaces project
- `OptionsRegistrationExtensions` in Tools wires options with DataAnnotations validation on startup
- Program.cs wired with options registration and auto-service registration
- 4 MSTests passing

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)