### PR TITLE
Stage 2: Place Management (Stories #41–#43)

### DIFF
--- a/src/TripsTracker.Business/CountryBusiness.cs
+++ b/src/TripsTracker.Business/CountryBusiness.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using TripsTracker.Data;
 using TripsTracker.Data.Entities;
 using TripsTracker.Domain;
@@ -12,4 +13,39 @@ public class CountryBusiness : BusinessBase<Country, CountryDto>, ICountryBusine
     public Task<List<CountryDto>> GetAllAsync(CancellationToken ct = default)
         => ToListAsync(BuildBaseQuery().Select(c => new CountryDto(
             c.Id, c.IsoNumeric, c.IsoAlpha2, c.Flag, c.Name, c.Region, c.IsHome, c.IsVisited)), ct);
+
+    public async Task<CountryDto?> SetVisitedAsync(int id, bool isVisited, CancellationToken ct = default)
+    {
+        var rows = await ExecuteUpdateAsync(
+            c => c.Id == id && !c.IsDeleted,
+            s => s.SetProperty(c => c.IsVisited, isVisited),
+            ct);
+        if (rows == 0) return null;
+        return await GetByIdAsync(
+            c => c.Id == id,
+            c => new CountryDto(c.Id, c.IsoNumeric, c.IsoAlpha2, c.Flag, c.Name, c.Region, c.IsHome, c.IsVisited),
+            ct);
+    }
+
+    public async Task<CountryDto?> SetHomeAsync(int id, CancellationToken ct = default)
+    {
+        // Clear existing home flag, then set on requested country
+        await Context.Set<Country>()
+            .Where(c => c.IsHome && !c.IsDeleted)
+            .ExecuteUpdateAsync(s => s.SetProperty(c => c.IsHome, false), ct);
+
+        var rows = await ExecuteUpdateAsync(
+            c => c.Id == id && !c.IsDeleted,
+            s =>
+            {
+                s.SetProperty(c => c.IsHome, true);
+                s.SetProperty(c => c.IsVisited, true);
+            },
+            ct);
+        if (rows == 0) return null;
+        return await GetByIdAsync(
+            c => c.Id == id,
+            c => new CountryDto(c.Id, c.IsoNumeric, c.IsoAlpha2, c.Flag, c.Name, c.Region, c.IsHome, c.IsVisited),
+            ct);
+    }
 }

--- a/src/TripsTracker.Business/PlaceBusiness.cs
+++ b/src/TripsTracker.Business/PlaceBusiness.cs
@@ -12,4 +12,52 @@ public class PlaceBusiness : BusinessBase<Place, PlaceDto>, IPlaceBusiness
     public Task<List<PlaceDto>> GetAllAsync(CancellationToken ct = default)
         => ToListAsync(BuildBaseQuery().Select(p => new PlaceDto(
             p.Id, p.Lon, p.Lat, p.Flag, p.CountryName, p.City, p.IsHome)), ct);
+
+    public Task<PlaceDto?> GetByIdAsync(int id, CancellationToken ct = default)
+        => GetByIdAsync(
+            p => p.Id == id,
+            p => new PlaceDto(p.Id, p.Lon, p.Lat, p.Flag, p.CountryName, p.City, p.IsHome),
+            ct);
+
+    public async Task<PlaceDto> CreateAsync(SavePlaceDto dto, CancellationToken ct = default)
+    {
+        var entity = new Place
+        {
+            Lon = dto.Lon,
+            Lat = dto.Lat,
+            Flag = dto.Flag,
+            CountryName = dto.CountryName,
+            City = dto.City,
+            IsHome = dto.IsHome
+        };
+        await InsertAsync(entity, ct);
+        return new PlaceDto(entity.Id, entity.Lon, entity.Lat, entity.Flag, entity.CountryName, entity.City, entity.IsHome);
+    }
+
+    public async Task<PlaceDto?> UpdateAsync(int id, SavePlaceDto dto, CancellationToken ct = default)
+    {
+        var rows = await ExecuteUpdateAsync(
+            p => p.Id == id && !p.IsDeleted,
+            s =>
+            {
+                s.SetProperty(p => p.Lon, dto.Lon);
+                s.SetProperty(p => p.Lat, dto.Lat);
+                s.SetProperty(p => p.Flag, dto.Flag);
+                s.SetProperty(p => p.CountryName, dto.CountryName);
+                s.SetProperty(p => p.City, dto.City);
+                s.SetProperty(p => p.IsHome, dto.IsHome);
+            },
+            ct);
+        if (rows == 0) return null;
+        return await GetByIdAsync(id, ct);
+    }
+
+    public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
+    {
+        var rows = await ExecuteUpdateAsync(
+            p => p.Id == id && !p.IsDeleted,
+            s => s.SetProperty(p => p.IsDeleted, true),
+            ct);
+        return rows > 0;
+    }
 }

--- a/src/TripsTracker.Business/VisitedStateBusiness.cs
+++ b/src/TripsTracker.Business/VisitedStateBusiness.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using TripsTracker.Data;
 using TripsTracker.Data.Entities;
 using TripsTracker.Domain;
@@ -12,4 +13,32 @@ public class VisitedStateBusiness : BusinessBase<VisitedState, VisitedStateDto>,
     public Task<List<VisitedStateDto>> GetAllAsync(CancellationToken ct = default)
         => ToListAsync(BuildBaseQuery().Select(vs => new VisitedStateDto(
             vs.Id, vs.CountryCode, vs.StateAbbr)), ct);
+
+    public async Task<VisitedStateDto> SetVisitedAsync(string countryCode, string stateAbbr, CancellationToken ct = default)
+    {
+        // Restore soft-deleted or insert new
+        var existing = await Context.Set<VisitedState>()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(vs => vs.CountryCode == countryCode && vs.StateAbbr == stateAbbr, ct);
+
+        if (existing is not null)
+        {
+            existing.IsDeleted = false;
+            await Context.SaveChangesAsync(ct);
+            return new VisitedStateDto(existing.Id, existing.CountryCode, existing.StateAbbr);
+        }
+
+        var entity = new VisitedState { CountryCode = countryCode, StateAbbr = stateAbbr };
+        await InsertAsync(entity, ct);
+        return new VisitedStateDto(entity.Id, entity.CountryCode, entity.StateAbbr);
+    }
+
+    public async Task<bool> ClearVisitedAsync(string countryCode, string stateAbbr, CancellationToken ct = default)
+    {
+        var rows = await ExecuteUpdateAsync(
+            vs => vs.CountryCode == countryCode && vs.StateAbbr == stateAbbr && !vs.IsDeleted,
+            s => s.SetProperty(vs => vs.IsDeleted, true),
+            ct);
+        return rows > 0;
+    }
 }

--- a/src/TripsTracker.Domain/SavePlaceDto.cs
+++ b/src/TripsTracker.Domain/SavePlaceDto.cs
@@ -1,0 +1,3 @@
+namespace TripsTracker.Domain;
+
+public record SavePlaceDto(double Lon, double Lat, string Flag, string CountryName, string City, bool IsHome);

--- a/src/TripsTracker.Functions/CountryFunctions.cs
+++ b/src/TripsTracker.Functions/CountryFunctions.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using TripsTracker.Interfaces.Business;
+
+namespace TripsTracker.Functions;
+
+public class CountryFunctions(ICountryBusiness countries)
+{
+    [Function("SetCountryVisited")]
+    public async Task<IActionResult> SetCountryVisited(
+        [HttpTrigger(AuthorizationLevel.Function, "put", Route = "countries/{id:int}/visited")] HttpRequest req,
+        int id,
+        CancellationToken ct)
+    {
+        bool isVisited = req.Query["value"] != "false";
+        var result = await countries.SetVisitedAsync(id, isVisited, ct);
+        return result is null ? new NotFoundResult() : new OkObjectResult(result);
+    }
+
+    [Function("SetCountryHome")]
+    public async Task<IActionResult> SetCountryHome(
+        [HttpTrigger(AuthorizationLevel.Function, "put", Route = "countries/{id:int}/home")] HttpRequest req,
+        int id,
+        CancellationToken ct)
+    {
+        var result = await countries.SetHomeAsync(id, ct);
+        return result is null ? new NotFoundResult() : new OkObjectResult(result);
+    }
+}

--- a/src/TripsTracker.Functions/PlaceFunctions.cs
+++ b/src/TripsTracker.Functions/PlaceFunctions.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using System.Text.Json;
+using TripsTracker.Domain;
+using TripsTracker.Interfaces.Business;
+
+namespace TripsTracker.Functions;
+
+public class PlaceFunctions(IPlaceBusiness places)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Function("CreatePlace")]
+    public async Task<IActionResult> CreatePlace(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "places")] HttpRequest req,
+        CancellationToken ct)
+    {
+        var dto = await JsonSerializer.DeserializeAsync<SavePlaceDto>(req.Body, JsonOptions, ct);
+        if (dto is null) return new BadRequestObjectResult("Invalid request body.");
+        var result = await places.CreateAsync(dto, ct);
+        return new CreatedAtRouteResult(null, new { id = result.Id }, result);
+    }
+
+    [Function("UpdatePlace")]
+    public async Task<IActionResult> UpdatePlace(
+        [HttpTrigger(AuthorizationLevel.Function, "put", Route = "places/{id:int}")] HttpRequest req,
+        int id,
+        CancellationToken ct)
+    {
+        var dto = await JsonSerializer.DeserializeAsync<SavePlaceDto>(req.Body, JsonOptions, ct);
+        if (dto is null) return new BadRequestObjectResult("Invalid request body.");
+        var result = await places.UpdateAsync(id, dto, ct);
+        return result is null ? new NotFoundResult() : new OkObjectResult(result);
+    }
+
+    [Function("DeletePlace")]
+    public async Task<IActionResult> DeletePlace(
+        [HttpTrigger(AuthorizationLevel.Function, "delete", Route = "places/{id:int}")] HttpRequest req,
+        int id,
+        CancellationToken ct)
+    {
+        var deleted = await places.DeleteAsync(id, ct);
+        return deleted ? new NoContentResult() : new NotFoundResult();
+    }
+}

--- a/src/TripsTracker.Functions/VisitedStateFunctions.cs
+++ b/src/TripsTracker.Functions/VisitedStateFunctions.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using TripsTracker.Interfaces.Business;
+
+namespace TripsTracker.Functions;
+
+public class VisitedStateFunctions(IVisitedStateBusiness states)
+{
+    [Function("SetVisitedState")]
+    public async Task<IActionResult> SetVisitedState(
+        [HttpTrigger(AuthorizationLevel.Function, "put", Route = "visited-states/{countryCode}/{stateAbbr}")] HttpRequest req,
+        string countryCode,
+        string stateAbbr,
+        CancellationToken ct)
+    {
+        var result = await states.SetVisitedAsync(countryCode.ToUpperInvariant(), stateAbbr.ToUpperInvariant(), ct);
+        return new OkObjectResult(result);
+    }
+
+    [Function("ClearVisitedState")]
+    public async Task<IActionResult> ClearVisitedState(
+        [HttpTrigger(AuthorizationLevel.Function, "delete", Route = "visited-states/{countryCode}/{stateAbbr}")] HttpRequest req,
+        string countryCode,
+        string stateAbbr,
+        CancellationToken ct)
+    {
+        var cleared = await states.ClearVisitedAsync(countryCode.ToUpperInvariant(), stateAbbr.ToUpperInvariant(), ct);
+        return cleared ? new NoContentResult() : new NotFoundResult();
+    }
+}

--- a/src/TripsTracker.Interfaces/Business/ICountryBusiness.cs
+++ b/src/TripsTracker.Interfaces/Business/ICountryBusiness.cs
@@ -5,4 +5,6 @@ namespace TripsTracker.Interfaces.Business;
 public interface ICountryBusiness
 {
     Task<List<CountryDto>> GetAllAsync(CancellationToken ct = default);
+    Task<CountryDto?> SetVisitedAsync(int id, bool isVisited, CancellationToken ct = default);
+    Task<CountryDto?> SetHomeAsync(int id, CancellationToken ct = default);
 }

--- a/src/TripsTracker.Interfaces/Business/IPlaceBusiness.cs
+++ b/src/TripsTracker.Interfaces/Business/IPlaceBusiness.cs
@@ -5,4 +5,8 @@ namespace TripsTracker.Interfaces.Business;
 public interface IPlaceBusiness
 {
     Task<List<PlaceDto>> GetAllAsync(CancellationToken ct = default);
+    Task<PlaceDto?> GetByIdAsync(int id, CancellationToken ct = default);
+    Task<PlaceDto> CreateAsync(SavePlaceDto dto, CancellationToken ct = default);
+    Task<PlaceDto?> UpdateAsync(int id, SavePlaceDto dto, CancellationToken ct = default);
+    Task<bool> DeleteAsync(int id, CancellationToken ct = default);
 }

--- a/src/TripsTracker.Interfaces/Business/IVisitedStateBusiness.cs
+++ b/src/TripsTracker.Interfaces/Business/IVisitedStateBusiness.cs
@@ -5,4 +5,6 @@ namespace TripsTracker.Interfaces.Business;
 public interface IVisitedStateBusiness
 {
     Task<List<VisitedStateDto>> GetAllAsync(CancellationToken ct = default);
+    Task<VisitedStateDto> SetVisitedAsync(string countryCode, string stateAbbr, CancellationToken ct = default);
+    Task<bool> ClearVisitedAsync(string countryCode, string stateAbbr, CancellationToken ct = default);
 }

--- a/src/TripsTracker.Web/src/App.tsx
+++ b/src/TripsTracker.Web/src/App.tsx
@@ -1,5 +1,11 @@
+import AppShell from '@/components/layout/AppShell';
 import MapPage from '@/pages/MapPage';
+import PlacesPage from '@/pages/places/PlacesPage';
 
 export default function App() {
-  return <MapPage />;
+  return (
+    <AppShell>
+      {view => view === 'map' ? <MapPage /> : <PlacesPage />}
+    </AppShell>
+  );
 }

--- a/src/TripsTracker.Web/src/App.tsx
+++ b/src/TripsTracker.Web/src/App.tsx
@@ -1,11 +1,16 @@
 import AppShell from '@/components/layout/AppShell';
 import MapPage from '@/pages/MapPage';
 import PlacesPage from '@/pages/places/PlacesPage';
+import CountriesPage from '@/pages/countries/CountriesPage';
 
 export default function App() {
   return (
     <AppShell>
-      {view => view === 'map' ? <MapPage /> : <PlacesPage />}
+      {view => {
+        if (view === 'map') return <MapPage />;
+        if (view === 'places') return <PlacesPage />;
+        return <CountriesPage />;
+      }}
     </AppShell>
   );
 }

--- a/src/TripsTracker.Web/src/api/hooks.ts
+++ b/src/TripsTracker.Web/src/api/hooks.ts
@@ -1,11 +1,36 @@
-import { useQuery } from '@tanstack/react-query';
-import type { Country, Place, VisitedState } from '@/types';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { Country, Place, SavePlace, VisitedState } from '@/types';
 import apiClient from './client';
 
 export function usePlaces() {
   return useQuery<Place[]>({
     queryKey: ['places'],
     queryFn: () => apiClient.get<Place[]>('/api/places').then(r => r.data),
+  });
+}
+
+export function useCreatePlace() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (dto: SavePlace) => apiClient.post<Place>('/api/places', dto).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['places'] }),
+  });
+}
+
+export function useUpdatePlace() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, dto }: { id: number; dto: SavePlace }) =>
+      apiClient.put<Place>(`/api/places/${id}`, dto).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['places'] }),
+  });
+}
+
+export function useDeletePlace() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => apiClient.delete(`/api/places/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['places'] }),
   });
 }
 

--- a/src/TripsTracker.Web/src/api/hooks.ts
+++ b/src/TripsTracker.Web/src/api/hooks.ts
@@ -41,9 +41,45 @@ export function useCountries() {
   });
 }
 
+export function useSetCountryVisited() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, isVisited }: { id: number; isVisited: boolean }) =>
+      apiClient.put<Country>(`/api/countries/${id}/visited?value=${isVisited}`).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['countries'] }),
+  });
+}
+
+export function useSetCountryHome() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) =>
+      apiClient.put<Country>(`/api/countries/${id}/home`).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['countries'] }),
+  });
+}
+
 export function useVisitedStates() {
   return useQuery<VisitedState[]>({
     queryKey: ['visited-states'],
     queryFn: () => apiClient.get<VisitedState[]>('/api/visited-states').then(r => r.data),
+  });
+}
+
+export function useSetVisitedState() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ countryCode, stateAbbr }: { countryCode: string; stateAbbr: string }) =>
+      apiClient.put<VisitedState>(`/api/visited-states/${countryCode}/${stateAbbr}`).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['visited-states'] }),
+  });
+}
+
+export function useClearVisitedState() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ countryCode, stateAbbr }: { countryCode: string; stateAbbr: string }) =>
+      apiClient.delete(`/api/visited-states/${countryCode}/${stateAbbr}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['visited-states'] }),
   });
 }

--- a/src/TripsTracker.Web/src/components/layout/AppShell.module.scss
+++ b/src/TripsTracker.Web/src/components/layout/AppShell.module.scss
@@ -1,0 +1,57 @@
+.shell {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100svh;
+  background: #0f172a;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 0 20px;
+  height: 48px;
+  background: #1e293b;
+  border-bottom: 1px solid #334155;
+  flex-shrink: 0;
+}
+
+.brand {
+  font-weight: 600;
+  font-size: 15px;
+  color: #f1f5f9;
+  letter-spacing: 0.02em;
+}
+
+.tabs {
+  display: flex;
+  gap: 4px;
+}
+
+.tab {
+  padding: 4px 14px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: #334155;
+    color: #f1f5f9;
+  }
+
+  &.active {
+    background: #334155;
+    color: #f1f5f9;
+  }
+}
+
+.main {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}

--- a/src/TripsTracker.Web/src/components/layout/AppShell.tsx
+++ b/src/TripsTracker.Web/src/components/layout/AppShell.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import styles from './AppShell.module.scss';
+
+type View = 'map' | 'places';
+
+interface Props {
+  children: (view: View) => React.ReactNode;
+}
+
+export default function AppShell({ children }: Props) {
+  const [view, setView] = useState<View>('map');
+
+  return (
+    <div className={styles.shell}>
+      <nav className={styles.nav}>
+        <span className={styles.brand}>TripsTracker</span>
+        <div className={styles.tabs}>
+          <button
+            className={`${styles.tab} ${view === 'map' ? styles.active : ''}`}
+            onClick={() => setView('map')}
+          >
+            Map
+          </button>
+          <button
+            className={`${styles.tab} ${view === 'places' ? styles.active : ''}`}
+            onClick={() => setView('places')}
+          >
+            Places
+          </button>
+        </div>
+      </nav>
+      <main className={styles.main}>{children(view)}</main>
+    </div>
+  );
+}

--- a/src/TripsTracker.Web/src/components/layout/AppShell.tsx
+++ b/src/TripsTracker.Web/src/components/layout/AppShell.tsx
@@ -1,11 +1,17 @@
 import { useState } from 'react';
 import styles from './AppShell.module.scss';
 
-type View = 'map' | 'places';
+export type View = 'map' | 'places' | 'countries';
 
 interface Props {
   children: (view: View) => React.ReactNode;
 }
+
+const TABS: { id: View; label: string }[] = [
+  { id: 'map', label: 'Map' },
+  { id: 'places', label: 'Places' },
+  { id: 'countries', label: 'Countries' },
+];
 
 export default function AppShell({ children }: Props) {
   const [view, setView] = useState<View>('map');
@@ -15,18 +21,15 @@ export default function AppShell({ children }: Props) {
       <nav className={styles.nav}>
         <span className={styles.brand}>TripsTracker</span>
         <div className={styles.tabs}>
-          <button
-            className={`${styles.tab} ${view === 'map' ? styles.active : ''}`}
-            onClick={() => setView('map')}
-          >
-            Map
-          </button>
-          <button
-            className={`${styles.tab} ${view === 'places' ? styles.active : ''}`}
-            onClick={() => setView('places')}
-          >
-            Places
-          </button>
+          {TABS.map(t => (
+            <button
+              key={t.id}
+              className={`${styles.tab} ${view === t.id ? styles.active : ''}`}
+              onClick={() => setView(t.id)}
+            >
+              {t.label}
+            </button>
+          ))}
         </div>
       </nav>
       <main className={styles.main}>{children(view)}</main>

--- a/src/TripsTracker.Web/src/main.tsx
+++ b/src/TripsTracker.Web/src/main.tsx
@@ -4,7 +4,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.tsx'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { staleTime: 0 } },
+})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/TripsTracker.Web/src/pages/MapPage.module.scss
+++ b/src/TripsTracker.Web/src/pages/MapPage.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100svh;
+  height: 100%;
   background: #0f172a;
   overflow: hidden;
 }

--- a/src/TripsTracker.Web/src/pages/countries/CountriesPage.module.scss
+++ b/src/TripsTracker.Web/src/pages/countries/CountriesPage.module.scss
@@ -1,0 +1,106 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  height: 100%;
+  padding: 20px;
+  overflow-y: auto;
+  color: #f1f5f9;
+}
+
+.section {
+  h2 {
+    margin: 0 0 12px;
+    font-size: 16px;
+    font-weight: 600;
+    color: #f1f5f9;
+  }
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+
+  th {
+    text-align: left;
+    padding: 8px 12px;
+    border-bottom: 1px solid #334155;
+    color: #94a3b8;
+    font-weight: 500;
+    text-transform: uppercase;
+    font-size: 11px;
+    letter-spacing: 0.06em;
+  }
+
+  td {
+    padding: 8px 12px;
+    border-bottom: 1px solid #1e293b;
+    color: #cbd5e1;
+    vertical-align: middle;
+  }
+
+  tr:hover td {
+    background: #1e293b;
+  }
+
+  input[type="checkbox"],
+  input[type="radio"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    accent-color: #4ade80;
+  }
+
+  input[type="radio"] {
+    accent-color: #60a5fa;
+  }
+}
+
+.flag {
+  font-size: 18px;
+  width: 36px;
+}
+
+.region {
+  color: #64748b;
+  font-size: 12px;
+}
+
+.stateGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.stateBtn {
+  width: 52px;
+  height: 38px;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  background: #1e293b;
+  color: #94a3b8;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+
+  &:hover {
+    border-color: #4ade80;
+    color: #4ade80;
+  }
+
+  &.visited {
+    background: #4ade8022;
+    border-color: #4ade80;
+    color: #4ade80;
+  }
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #94a3b8;
+}

--- a/src/TripsTracker.Web/src/pages/countries/CountriesPage.tsx
+++ b/src/TripsTracker.Web/src/pages/countries/CountriesPage.tsx
@@ -1,0 +1,99 @@
+import {
+  useCountries, useVisitedStates,
+  useSetCountryVisited, useSetCountryHome,
+  useSetVisitedState, useClearVisitedState,
+} from '@/api/hooks';
+import type { Country } from '@/types';
+import styles from './CountriesPage.module.scss';
+
+// Brazil state list
+const BR_STATES = [
+  'AC','AL','AM','AP','BA','CE','DF','ES','GO',
+  'MA','MG','MS','MT','PA','PB','PE','PI','PR',
+  'RJ','RN','RO','RR','RS','SC','SE','SP','TO',
+];
+
+export default function CountriesPage() {
+  const { data: countries = [], isLoading: cLoading } = useCountries();
+  const { data: visitedStates = [], isLoading: vsLoading } = useVisitedStates();
+  const setVisited = useSetCountryVisited();
+  const setHome = useSetCountryHome();
+  const setStateMark = useSetVisitedState();
+  const clearStateMark = useClearVisitedState();
+
+  const visitedBrStates = new Set(
+    visitedStates.filter(s => s.countryCode === 'BR').map(s => s.stateAbbr)
+  );
+
+  if (cLoading || vsLoading) return <div className={styles.loading}>Loading…</div>;
+
+  const sorted = [...countries].sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.section}>
+        <h2>Countries</h2>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th></th>
+              <th>Country</th>
+              <th>Region</th>
+              <th>Visited</th>
+              <th>Home</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((c: Country) => (
+              <tr key={c.id}>
+                <td className={styles.flag}>{c.flag}</td>
+                <td>{c.name}</td>
+                <td className={styles.region}>{c.region}</td>
+                <td>
+                  <input
+                    type="checkbox"
+                    checked={c.isVisited}
+                    disabled={c.isHome}
+                    onChange={e => setVisited.mutate({ id: c.id, isVisited: e.target.checked })}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="radio"
+                    name="home"
+                    checked={c.isHome}
+                    onChange={() => setHome.mutate(c.id)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className={styles.section}>
+        <h2>Brazil — visited states</h2>
+        <div className={styles.stateGrid}>
+          {BR_STATES.map(abbr => {
+            const visited = visitedBrStates.has(abbr);
+            return (
+              <button
+                key={abbr}
+                className={`${styles.stateBtn} ${visited ? styles.visited : ''}`}
+                onClick={() => {
+                  if (visited) {
+                    clearStateMark.mutate({ countryCode: 'BR', stateAbbr: abbr });
+                  } else {
+                    setStateMark.mutate({ countryCode: 'BR', stateAbbr: abbr });
+                  }
+                }}
+              >
+                {abbr}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/TripsTracker.Web/src/pages/places/DeleteConfirm.module.scss
+++ b/src/TripsTracker.Web/src/pages/places/DeleteConfirm.module.scss
@@ -1,0 +1,62 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.modal {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 10px;
+  padding: 24px;
+  width: 380px;
+  color: #f1f5f9;
+
+  h3 {
+    margin: 0 0 12px;
+    font-size: 16px;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0 0 20px;
+    font-size: 13px;
+    color: #94a3b8;
+    line-height: 1.5;
+  }
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+
+  button {
+    padding: 7px 16px;
+    border-radius: 6px;
+    border: 1px solid #334155;
+    background: transparent;
+    color: #94a3b8;
+    font-size: 13px;
+    cursor: pointer;
+
+    &:hover {
+      background: #334155;
+      color: #f1f5f9;
+    }
+  }
+}
+
+.deleteBtn {
+  border-color: #f87171 !important;
+  color: #f87171 !important;
+
+  &:hover {
+    background: #f87171 !important;
+    color: #0f172a !important;
+  }
+}

--- a/src/TripsTracker.Web/src/pages/places/DeleteConfirm.tsx
+++ b/src/TripsTracker.Web/src/pages/places/DeleteConfirm.tsx
@@ -1,0 +1,26 @@
+import type { Place } from '@/types';
+import styles from './DeleteConfirm.module.scss';
+
+interface Props {
+  place: Place;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function DeleteConfirm({ place, onConfirm, onCancel }: Props) {
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <h3>Delete place</h3>
+        <p>
+          Delete <strong>{place.flag} {place.city}</strong> ({place.countryName})?
+          This cannot be undone.
+        </p>
+        <div className={styles.actions}>
+          <button onClick={onCancel}>Cancel</button>
+          <button className={styles.deleteBtn} onClick={onConfirm}>Delete</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/TripsTracker.Web/src/pages/places/PlaceForm.module.scss
+++ b/src/TripsTracker.Web/src/pages/places/PlaceForm.module.scss
@@ -1,0 +1,147 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: #1e293b;
+  border: 1px solid #334155;
+  border-radius: 10px;
+  width: 560px;
+  max-height: 90svh;
+  overflow-y: auto;
+  color: #f1f5f9;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid #334155;
+
+  h3 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+  }
+}
+
+.close {
+  background: none;
+  border: none;
+  color: #94a3b8;
+  font-size: 20px;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 4px;
+
+  &:hover { color: #f1f5f9; }
+}
+
+.miniMap {
+  width: 100%;
+  height: 200px;
+  display: block;
+  background: #0f172a;
+  cursor: crosshair;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 20px;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+    color: #94a3b8;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  input[type="text"],
+  input[type="number"] {
+    padding: 7px 10px;
+    background: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 6px;
+    color: #f1f5f9;
+    font-size: 13px;
+
+    &:focus {
+      outline: none;
+      border-color: #4ade80;
+    }
+  }
+}
+
+.coords {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.checkLabel {
+  flex-direction: row !important;
+  align-items: center;
+  gap: 8px !important;
+  font-size: 13px !important;
+  text-transform: none !important;
+  letter-spacing: 0 !important;
+  color: #cbd5e1 !important;
+
+  input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    accent-color: #4ade80;
+  }
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 4px;
+
+  button {
+    padding: 7px 16px;
+    border-radius: 6px;
+    border: 1px solid #334155;
+    background: transparent;
+    color: #94a3b8;
+    font-size: 13px;
+    cursor: pointer;
+
+    &:hover {
+      background: #334155;
+      color: #f1f5f9;
+    }
+  }
+}
+
+.saveBtn {
+  background: #4ade80 !important;
+  color: #0f172a !important;
+  border-color: #4ade80 !important;
+  font-weight: 600 !important;
+
+  &:hover {
+    background: #86efac !important;
+    border-color: #86efac !important;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}

--- a/src/TripsTracker.Web/src/pages/places/PlaceForm.tsx
+++ b/src/TripsTracker.Web/src/pages/places/PlaceForm.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from 'react';
+import * as d3 from 'd3';
+import type { GeoPermissibleObjects } from 'd3';
+import { useCreatePlace, useUpdatePlace } from '@/api/hooks';
+import type { Place, SavePlace } from '@/types';
+import styles from './PlaceForm.module.scss';
+
+interface Props {
+  place: Place | null;
+  onClose: () => void;
+}
+
+const COUNTRY_FLAGS: Record<string, string> = {
+  'United Kingdom': '🏴󠁧󠁢󠁳󠁣󠁴󠁿', 'Portugal': '🇵🇹', 'Spain': '🇪🇸', 'Italy': '🇮🇹',
+  'Malta': '🇲🇹', 'Switzerland': '🇨🇭', 'Germany': '🇩🇪', 'Austria': '🇦🇹',
+  'Hungary': '🇭🇺', 'Romania': '🇷🇴', 'Bulgaria': '🇧🇬', 'Croatia': '🇭🇷',
+  'Sweden': '🇸🇪', 'Greece': '🇬🇷', 'Turkey': '🇹🇷', 'Israel': '🇮🇱',
+  'Cape Verde': '🇨🇻', 'United States': '🇺🇸', 'Argentina': '🇦🇷', 'Brazil': '🇧🇷',
+};
+
+export default function PlaceForm({ place, onClose }: Props) {
+  const create = useCreatePlace();
+  const update = useUpdatePlace();
+
+  const [lon, setLon] = useState(place?.lon ?? 0);
+  const [lat, setLat] = useState(place?.lat ?? 0);
+  const [city, setCity] = useState(place?.city ?? '');
+  const [countryName, setCountryName] = useState(place?.countryName ?? '');
+  const [flag, setFlag] = useState(place?.flag ?? '');
+  const [isHome, setIsHome] = useState(place?.isHome ?? false);
+
+  const mapRef = useRef<SVGSVGElement>(null);
+  const [worldGeo, setWorldGeo] = useState<GeoJSON.FeatureCollection | null>(null);
+
+  useEffect(() => {
+    fetch('/geo/world-110m.geojson').then(r => r.json()).then(d => setWorldGeo(d as GeoJSON.FeatureCollection));
+  }, []);
+
+  useEffect(() => {
+    if (!mapRef.current || !worldGeo) return;
+
+    const width = mapRef.current.clientWidth || 500;
+    const height = mapRef.current.clientHeight || 260;
+    const svg = d3.select(mapRef.current);
+    svg.selectAll('*').remove();
+
+    const projection = d3.geoNaturalEarth1()
+      .scale(width / 6.3)
+      .translate([width / 2, height / 2]);
+    const path = d3.geoPath().projection(projection);
+
+    const g = svg.append('g');
+
+    g.selectAll<SVGPathElement, GeoJSON.Feature>('path')
+      .data(worldGeo.features)
+      .join('path')
+      .attr('d', f => path(f as GeoPermissibleObjects) ?? '')
+      .attr('fill', '#1e293b')
+      .attr('stroke', '#334155')
+      .attr('stroke-width', 0.5);
+
+    // Pin for current coords
+    const pinCoords = projection([lon, lat]);
+    if (pinCoords) {
+      g.append('circle')
+        .attr('cx', pinCoords[0])
+        .attr('cy', pinCoords[1])
+        .attr('r', 6)
+        .attr('fill', '#f97316')
+        .attr('stroke', '#fff')
+        .attr('stroke-width', 1.5);
+    }
+
+    svg.style('cursor', 'crosshair').on('click', (event: MouseEvent) => {
+      const [mx, my] = d3.pointer(event);
+      const coords = projection.invert?.([mx, my]);
+      if (coords) {
+        setLon(parseFloat(coords[0].toFixed(4)));
+        setLat(parseFloat(coords[1].toFixed(4)));
+      }
+    });
+  }, [worldGeo, lon, lat]);
+
+  // Auto-fill flag from country name
+  useEffect(() => {
+    const f = COUNTRY_FLAGS[countryName];
+    if (f) setFlag(f);
+  }, [countryName]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const dto: SavePlace = { lon, lat, flag, countryName, city, isHome };
+    if (place) {
+      update.mutate({ id: place.id, dto }, { onSuccess: onClose });
+    } else {
+      create.mutate(dto, { onSuccess: onClose });
+    }
+  };
+
+  const isPending = create.isPending || update.isPending;
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <div className={styles.header}>
+          <h3>{place ? 'Edit place' : 'Add place'}</h3>
+          <button className={styles.close} onClick={onClose}>×</button>
+        </div>
+
+        <svg ref={mapRef} className={styles.miniMap} />
+
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <div className={styles.coords}>
+            <label>
+              Lon
+              <input type="number" step="0.0001" value={lon} onChange={e => setLon(parseFloat(e.target.value))} required />
+            </label>
+            <label>
+              Lat
+              <input type="number" step="0.0001" value={lat} onChange={e => setLat(parseFloat(e.target.value))} required />
+            </label>
+          </div>
+
+          <label>
+            City
+            <input type="text" value={city} onChange={e => setCity(e.target.value)} required />
+          </label>
+
+          <label>
+            Country
+            <input
+              type="text"
+              value={countryName}
+              onChange={e => setCountryName(e.target.value)}
+              list="country-list"
+              required
+            />
+            <datalist id="country-list">
+              {Object.keys(COUNTRY_FLAGS).map(c => <option key={c} value={c} />)}
+            </datalist>
+          </label>
+
+          <label>
+            Flag
+            <input type="text" value={flag} onChange={e => setFlag(e.target.value)} required />
+          </label>
+
+          <label className={styles.checkLabel}>
+            <input type="checkbox" checked={isHome} onChange={e => setIsHome(e.target.checked)} />
+            Home location
+          </label>
+
+          <div className={styles.actions}>
+            <button type="button" onClick={onClose}>Cancel</button>
+            <button type="submit" className={styles.saveBtn} disabled={isPending}>
+              {isPending ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/TripsTracker.Web/src/pages/places/PlacesPage.module.scss
+++ b/src/TripsTracker.Web/src/pages/places/PlacesPage.module.scss
@@ -1,0 +1,110 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 20px;
+  color: #f1f5f9;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+
+  h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #f1f5f9;
+  }
+}
+
+.addBtn {
+  padding: 6px 14px;
+  background: #4ade80;
+  color: #0f172a;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    background: #86efac;
+  }
+}
+
+.tableWrapper {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+
+  th {
+    text-align: left;
+    padding: 8px 12px;
+    border-bottom: 1px solid #334155;
+    color: #94a3b8;
+    font-weight: 500;
+    text-transform: uppercase;
+    font-size: 11px;
+    letter-spacing: 0.06em;
+  }
+
+  td {
+    padding: 8px 12px;
+    border-bottom: 1px solid #1e293b;
+    color: #cbd5e1;
+  }
+
+  tr:hover td {
+    background: #1e293b;
+  }
+}
+
+.flag {
+  font-size: 18px;
+  width: 36px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+
+  button {
+    padding: 3px 10px;
+    border-radius: 4px;
+    border: 1px solid #334155;
+    background: transparent;
+    color: #94a3b8;
+    font-size: 12px;
+    cursor: pointer;
+
+    &:hover {
+      background: #334155;
+      color: #f1f5f9;
+    }
+  }
+}
+
+.deleteBtn {
+  &:hover {
+    border-color: #f87171 !important;
+    color: #f87171 !important;
+    background: transparent !important;
+  }
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #94a3b8;
+}

--- a/src/TripsTracker.Web/src/pages/places/PlacesPage.tsx
+++ b/src/TripsTracker.Web/src/pages/places/PlacesPage.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { usePlaces, useDeletePlace } from '@/api/hooks';
+import type { Place } from '@/types';
+import PlaceForm from './PlaceForm';
+import DeleteConfirm from './DeleteConfirm';
+import styles from './PlacesPage.module.scss';
+
+export default function PlacesPage() {
+  const { data: places = [], isLoading } = usePlaces();
+  const [editing, setEditing] = useState<Place | null | 'new'>(null);
+  const [deleting, setDeleting] = useState<Place | null>(null);
+  const deletePlace = useDeletePlace();
+
+  if (isLoading) return <div className={styles.loading}>Loading…</div>;
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <h2>Places</h2>
+        <button className={styles.addBtn} onClick={() => setEditing('new')}>
+          + Add place
+        </button>
+      </div>
+
+      <div className={styles.tableWrapper}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th></th>
+              <th>City</th>
+              <th>Country</th>
+              <th>Lon</th>
+              <th>Lat</th>
+              <th>Home</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {places.map(p => (
+              <tr key={p.id}>
+                <td className={styles.flag}>{p.flag}</td>
+                <td>{p.city}</td>
+                <td>{p.countryName}</td>
+                <td>{p.lon.toFixed(4)}</td>
+                <td>{p.lat.toFixed(4)}</td>
+                <td>{p.isHome ? '✓' : ''}</td>
+                <td className={styles.actions}>
+                  <button onClick={() => setEditing(p)}>Edit</button>
+                  <button className={styles.deleteBtn} onClick={() => setDeleting(p)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {editing !== null && (
+        <PlaceForm
+          place={editing === 'new' ? null : editing}
+          onClose={() => setEditing(null)}
+        />
+      )}
+
+      {deleting && (
+        <DeleteConfirm
+          place={deleting}
+          onConfirm={() => {
+            deletePlace.mutate(deleting.id);
+            setDeleting(null);
+          }}
+          onCancel={() => setDeleting(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/TripsTracker.Web/src/types/index.ts
+++ b/src/TripsTracker.Web/src/types/index.ts
@@ -19,6 +19,15 @@ export interface Country {
   isVisited: boolean;
 }
 
+export interface SavePlace {
+  lon: number;
+  lat: number;
+  flag: string;
+  countryName: string;
+  city: string;
+  isHome: boolean;
+}
+
 export interface VisitedState {
   id: number;
   countryCode: string;


### PR DESCRIPTION
## Summary

- **Story #41** — Places CRUD: POST/PUT/DELETE API endpoints (`PlaceFunctions`), frontend Places page with table, add/edit modal form (mini D3 click-to-pin map), delete confirmation
- **Story #42** — Countries & states management: PUT endpoints for visited/home flags (`CountryFunctions`), PUT/DELETE endpoints for visited states (`VisitedStateFunctions`), Countries page with checkbox/radio table and Brazil state toggle grid
- **Story #43** — Map live refresh: React Query mutations call `invalidateQueries` on success; `staleTime: 0` ensures map always shows fresh data after any change
- **Fix** — `TripsTracker.Web.esproj` added and linked to solution (merged from fix/add-esproj via PR #71)

## Test plan

- [ ] Add a new place by clicking on the mini map in the form — verify pin appears on world map
- [ ] Edit an existing place — verify map updates immediately without page reload
- [ ] Delete a place — verify it disappears from map and Places list
- [ ] Toggle a country as visited — verify colour changes on world map
- [ ] Set a country as home — verify previous home is cleared, new home is highlighted
- [ ] Toggle Brazil states on/off — verify state count in stats bar updates
- [ ] Toggle US states on/off — verify state count in stats bar updates
- [ ] Open solution in Visual Studio — verify TripsTracker.Web appears in Solution Explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)