### PR TITLE
Fix: add TripsTracker.Web.esproj and link to solution

### DIFF
--- a/TripsTracker.slnx
+++ b/TripsTracker.slnx
@@ -7,6 +7,7 @@
     <Project Path="src/TripsTracker.Interfaces/TripsTracker.Interfaces.csproj" />
     <Project Path="src/TripsTracker.Process/TripsTracker.Process.csproj" />
     <Project Path="src/TripsTracker.Tools/TripsTracker.Tools.csproj" />
+    <Project Path="src/TripsTracker.Web/TripsTracker.Web.esproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/TripsTracker.Tests/TripsTracker.Tests.csproj" />

--- a/src/TripsTracker.Web/TripsTracker.Web.esproj
+++ b/src/TripsTracker.Web/TripsTracker.Web.esproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.4991845">
+  <PropertyGroup>
+    <BuildOutputFolder>dist</BuildOutputFolder>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

Adds a `.esproj` (Microsoft.VisualStudio.JavaScript.Sdk/1.0.4991845) to `src/TripsTracker.Web` so the Vite/React frontend is:
- Visible inside Visual Studio alongside the .NET projects
- Configurable as a multi-startup project with `TripsTracker.Functions` (F5 starts both)
- Publishable to Azure Static Web Apps from Visual Studio

## Test plan
- [ ] Open `TripsTracker.slnx` in Visual Studio — verify `TripsTracker.Web` appears in Solution Explorer
- [ ] Set multiple startup projects (Functions + Web) and confirm F5 starts both

🤖 Generated with [Claude Code](https://claude.com/claude-code)