### PR TITLE
Tech debt: remove TDomain from base classes (#104)

### DIFF
--- a/src/TripsTracker.Business/CountryBusiness.cs
+++ b/src/TripsTracker.Business/CountryBusiness.cs
@@ -6,13 +6,13 @@ using TripsTracker.Interfaces.Business;
 
 namespace TripsTracker.Business;
 
-public class CountryBusiness : BusinessBase<Country, CountryDto>, ICountryBusiness
+public class CountryBusiness : BusinessBase<Country>, ICountryBusiness
 {
     public CountryBusiness(TripsTrackerDbContext context) : base(context) { }
 
     public Task<List<CountryDto>> GetAllAsync(CancellationToken ct = default)
-        => ToListAsync(BuildBaseQuery().Select(c => new CountryDto(
-            c.Id, c.IsoNumeric, c.IsoAlpha2, c.Flag, c.Name, c.Region, c.IsHome, c.IsVisited)), ct);
+        => BuildBaseQuery().Select(c => new CountryDto(
+            c.Id, c.IsoNumeric, c.IsoAlpha2, c.Flag, c.Name, c.Region, c.IsHome, c.IsVisited)).ToListAsync(ct);
 
     public async Task<CountryDto?> SetVisitedAsync(int id, bool isVisited, CancellationToken ct = default)
     {
@@ -21,10 +21,10 @@ public class CountryBusiness : BusinessBase<Country, CountryDto>, ICountryBusine
             s => s.SetProperty(c => c.IsVisited, isVisited),
             ct);
         if (rows == 0) return null;
-        return await GetByIdAsync(
-            c => c.Id == id,
-            c => new CountryDto(c.Id, c.IsoNumeric, c.IsoAlpha2, c.Flag, c.Name, c.Region, c.IsHome, c.IsVisited),
-            ct);
+        return await BuildBaseQuery()
+            .Where(c => c.Id == id)
+            .Select(c => new CountryDto(c.Id, c.IsoNumeric, c.IsoAlpha2, c.Flag, c.Name, c.Region, c.IsHome, c.IsVisited))
+            .FirstOrDefaultAsync(ct);
     }
 
     public async Task<CountryDto?> SetHomeAsync(int id, CancellationToken ct = default)
@@ -43,9 +43,9 @@ public class CountryBusiness : BusinessBase<Country, CountryDto>, ICountryBusine
             },
             ct);
         if (rows == 0) return null;
-        return await GetByIdAsync(
-            c => c.Id == id,
-            c => new CountryDto(c.Id, c.IsoNumeric, c.IsoAlpha2, c.Flag, c.Name, c.Region, c.IsHome, c.IsVisited),
-            ct);
+        return await BuildBaseQuery()
+            .Where(c => c.Id == id)
+            .Select(c => new CountryDto(c.Id, c.IsoNumeric, c.IsoAlpha2, c.Flag, c.Name, c.Region, c.IsHome, c.IsVisited))
+            .FirstOrDefaultAsync(ct);
     }
 }

--- a/src/TripsTracker.Business/PlaceBusiness.cs
+++ b/src/TripsTracker.Business/PlaceBusiness.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using TripsTracker.Data;
 using TripsTracker.Data.Entities;
 using TripsTracker.Domain;
@@ -5,19 +6,19 @@ using TripsTracker.Interfaces.Business;
 
 namespace TripsTracker.Business;
 
-public class PlaceBusiness : BusinessBase<Place, PlaceDto>, IPlaceBusiness
+public class PlaceBusiness : BusinessBase<Place>, IPlaceBusiness
 {
     public PlaceBusiness(TripsTrackerDbContext context) : base(context) { }
 
     public Task<List<PlaceDto>> GetAllAsync(CancellationToken ct = default)
-        => ToListAsync(BuildBaseQuery().Select(p => new PlaceDto(
-            p.Id, p.Lon, p.Lat, p.Flag, p.CountryName, p.City, p.IsHome)), ct);
+        => BuildBaseQuery().Select(p => new PlaceDto(
+            p.Id, p.Lon, p.Lat, p.Flag, p.CountryName, p.City, p.IsHome)).ToListAsync(ct);
 
     public Task<PlaceDto?> GetByIdAsync(int id, CancellationToken ct = default)
-        => GetByIdAsync(
-            p => p.Id == id,
-            p => new PlaceDto(p.Id, p.Lon, p.Lat, p.Flag, p.CountryName, p.City, p.IsHome),
-            ct);
+        => BuildBaseQuery()
+            .Where(p => p.Id == id)
+            .Select(p => new PlaceDto(p.Id, p.Lon, p.Lat, p.Flag, p.CountryName, p.City, p.IsHome))
+            .FirstOrDefaultAsync(ct);
 
     public async Task<PlaceDto> CreateAsync(SavePlaceDto dto, CancellationToken ct = default)
     {

--- a/src/TripsTracker.Business/VisitedStateBusiness.cs
+++ b/src/TripsTracker.Business/VisitedStateBusiness.cs
@@ -6,13 +6,13 @@ using TripsTracker.Interfaces.Business;
 
 namespace TripsTracker.Business;
 
-public class VisitedStateBusiness : BusinessBase<VisitedState, VisitedStateDto>, IVisitedStateBusiness
+public class VisitedStateBusiness : BusinessBase<VisitedState>, IVisitedStateBusiness
 {
     public VisitedStateBusiness(TripsTrackerDbContext context) : base(context) { }
 
     public Task<List<VisitedStateDto>> GetAllAsync(CancellationToken ct = default)
-        => ToListAsync(BuildBaseQuery().Select(vs => new VisitedStateDto(
-            vs.Id, vs.CountryCode, vs.StateAbbr)), ct);
+        => BuildBaseQuery().Select(vs => new VisitedStateDto(
+            vs.Id, vs.CountryCode, vs.StateAbbr)).ToListAsync(ct);
 
     public async Task<VisitedStateDto> SetVisitedAsync(string countryCode, string stateAbbr, CancellationToken ct = default)
     {

--- a/src/TripsTracker.Data/BusinessBase.cs
+++ b/src/TripsTracker.Data/BusinessBase.cs
@@ -4,28 +4,29 @@ namespace TripsTracker.Data;
 
 /// <summary>
 /// Top-level base class for all business classes.
-/// Combines query infrastructure from <see cref="QueryBase{TEntity,TDomain}"/>
-/// with generic CRUD operations from <see cref="CrudBase{TEntity,TDomain}"/>.
+/// Combines query infrastructure from <see cref="QueryBase{TEntity}"/>
+/// with generic CRUD operations from <see cref="CrudBase{TEntity}"/>.
 ///
 /// Business class usage:
 /// <code>
-/// public class TripBusiness : BusinessBase&lt;TripEntity, TripDomain&gt;, ITripBusiness
+/// public class TripBusiness : BusinessBase&lt;TripEntity&gt;, ITripBusiness
 /// {
 ///     public TripBusiness(AppDbContext context) : base(context) { }
 ///
 ///     protected override IQueryable&lt;TripEntity&gt; BuildBaseQuery()
 ///         => base.BuildBaseQuery().Where(t => !t.IsDeleted);
 ///
-///     public async Task&lt;TripDomain?&gt; GetByIdAsync(int id, CancellationToken ct = default)
-///         => await GetByIdAsync(t => t.Id == id, t => new TripDomain(...), ct);
+///     public async Task&lt;TripDto?&gt; GetByIdAsync(int id, CancellationToken ct = default)
+///         => await BuildBaseQuery()
+///             .Where(t => t.Id == id)
+///             .Select(t => new TripDto(...))
+///             .FirstOrDefaultAsync(ct);
 /// }
 /// </code>
 /// </summary>
 /// <typeparam name="TEntity">The EF Core entity type (strong table owned by this class).</typeparam>
-/// <typeparam name="TDomain">The primary domain projection type.</typeparam>
-public abstract class BusinessBase<TEntity, TDomain> : CrudBase<TEntity, TDomain>
+public abstract class BusinessBase<TEntity> : CrudBase<TEntity>
     where TEntity : class
-    where TDomain : class
 {
     protected BusinessBase(DbContext context) : base(context) { }
 }

--- a/src/TripsTracker.Data/CrudBase.cs
+++ b/src/TripsTracker.Data/CrudBase.cs
@@ -11,10 +11,8 @@ namespace TripsTracker.Data;
 /// preventing cross-contamination between sequential business calls in the same scope.
 /// </summary>
 /// <typeparam name="TEntity">The EF Core entity type.</typeparam>
-/// <typeparam name="TDomain">The domain projection type.</typeparam>
-public abstract class CrudBase<TEntity, TDomain> : QueryBase<TEntity, TDomain>
+public abstract class CrudBase<TEntity> : QueryBase<TEntity>
     where TEntity : class
-    where TDomain : class
 {
     protected CrudBase(DbContext context) : base(context) { }
 
@@ -26,20 +24,6 @@ public abstract class CrudBase<TEntity, TDomain> : QueryBase<TEntity, TDomain>
         Context.Set<TEntity>().Add(entity);
         await Context.SaveChangesAsync(ct);
     }
-
-    /// <summary>
-    /// Returns a single matching domain projection, or null if not found.
-    /// Uses <see cref="QueryBase{TEntity,TDomain}.BuildBaseQuery"/> as the base — all common
-    /// filters (soft-delete etc.) are automatically applied.
-    /// </summary>
-    protected async Task<TDomain?> GetByIdAsync(
-        Expression<Func<TEntity, bool>> predicate,
-        Expression<Func<TEntity, TDomain>> projection,
-        CancellationToken ct = default)
-        => await BuildBaseQuery()
-            .Where(predicate)
-            .Select(projection)
-            .FirstOrDefaultAsync(ct);
 
     /// <summary>
     /// Updates specific fields on all rows matching the predicate without loading any records.

--- a/src/TripsTracker.Data/QueryBase.cs
+++ b/src/TripsTracker.Data/QueryBase.cs
@@ -1,18 +1,16 @@
 using Microsoft.EntityFrameworkCore;
-using System.Linq.Expressions;
 
 namespace TripsTracker.Data;
 
 /// <summary>
 /// Protected query infrastructure for business classes.
-/// Provides <see cref="BuildBaseQuery"/> as the mandatory entry point for all queries,
-/// and execution helpers that consume typed <see cref="IQueryable{TDomain}"/> projections.
+/// Provides <see cref="BuildBaseQuery"/> as the mandatory entry point for all queries.
+/// Always applies AsNoTracking — reads never need change tracking.
+/// Override in subclasses to add common filters (e.g. soft-delete, tenant isolation).
 /// </summary>
 /// <typeparam name="TEntity">The EF Core entity type (database row).</typeparam>
-/// <typeparam name="TDomain">The domain projection type returned to callers.</typeparam>
-public abstract class QueryBase<TEntity, TDomain>
+public abstract class QueryBase<TEntity>
     where TEntity : class
-    where TDomain : class
 {
     protected readonly DbContext Context;
 
@@ -28,29 +26,4 @@ public abstract class QueryBase<TEntity, TDomain>
     /// </summary>
     protected virtual IQueryable<TEntity> BuildBaseQuery()
         => Context.Set<TEntity>().AsNoTracking();
-
-    /// <summary>
-    /// Executes the projected query and returns all matching results.
-    /// </summary>
-    protected async Task<List<TDomain>> ToListAsync(
-        IQueryable<TDomain> query,
-        CancellationToken ct = default)
-        => await query.ToListAsync(ct);
-
-    /// <summary>
-    /// Executes the projected query and returns the first match or null.
-    /// </summary>
-    protected async Task<TDomain?> FirstOrDefaultAsync(
-        IQueryable<TDomain> query,
-        CancellationToken ct = default)
-        => await query.FirstOrDefaultAsync(ct);
-
-    /// <summary>
-    /// Applies a where-clause to <see cref="BuildBaseQuery"/> and projects to the domain type.
-    /// Use this as the standard way to compose queries from the base query.
-    /// </summary>
-    protected IQueryable<TDomain> ApplyFilter(
-        Expression<Func<TEntity, bool>> predicate,
-        Expression<Func<TEntity, TDomain>> projection)
-        => BuildBaseQuery().Where(predicate).Select(projection);
 }

--- a/tests/TripsTracker.Tests/Data/BusinessBaseTests.cs
+++ b/tests/TripsTracker.Tests/Data/BusinessBaseTests.cs
@@ -24,7 +24,7 @@ public class BusinessBaseTests
         public DbSet<TripEntity> Trips => Set<TripEntity>();
     }
 
-    private class TripBusiness : BusinessBase<TripEntity, TripDomain>
+    private class TripBusiness : BusinessBase<TripEntity>
     {
         public TripBusiness(TestDbContext context) : base(context) { }
 
@@ -35,10 +35,13 @@ public class BusinessBaseTests
             => InsertAsync(entity, ct);
 
         public Task<TripDomain?> GetTripByIdAsync(int id, CancellationToken ct = default)
-            => GetByIdAsync(t => t.Id == id, t => new TripDomain(t.Id, t.Name), ct);
+            => BuildBaseQuery()
+                .Where(t => t.Id == id)
+                .Select(t => new TripDomain(t.Id, t.Name))
+                .FirstOrDefaultAsync(ct);
 
         public Task<List<TripDomain>> GetAllTripsAsync(CancellationToken ct = default)
-            => ToListAsync(BuildBaseQuery().Select(t => new TripDomain(t.Id, t.Name)), ct);
+            => BuildBaseQuery().Select(t => new TripDomain(t.Id, t.Name)).ToListAsync(ct);
 
         public Task<int> UpdateTripNameAsync(int id, string newName, CancellationToken ct = default)
             => ExecuteUpdateAsync(t => t.Id == id, s => s.SetProperty(t => t.Name, newName), ct);
@@ -47,7 +50,10 @@ public class BusinessBaseTests
             => ExecuteDeleteAsync(t => t.Id == id, ct);
 
         public Task<TripDomain?> FindByNameAsync(string name, CancellationToken ct = default)
-            => FirstOrDefaultAsync(ApplyFilter(t => t.Name == name, t => new TripDomain(t.Id, t.Name)), ct);
+            => BuildBaseQuery()
+                .Where(t => t.Name == name)
+                .Select(t => new TripDomain(t.Id, t.Name))
+                .FirstOrDefaultAsync(ct);
     }
 
     /// <summary>
@@ -107,7 +113,7 @@ public class BusinessBaseTests
 
     #endregion
 
-    #region GetByIdAsync
+    #region GetTripByIdAsync
 
     [TestMethod]
     public async Task GetByIdAsync_ReturnsMatchingDomainProjection()
@@ -205,7 +211,7 @@ public class BusinessBaseTests
 
     #endregion
 
-    #region BuildBaseQuery + ApplyFilter
+    #region BuildBaseQuery
 
     [TestMethod]
     public async Task BuildBaseQuery_ExcludesSoftDeletedEntities()
@@ -223,7 +229,7 @@ public class BusinessBaseTests
     }
 
     [TestMethod]
-    public async Task ApplyFilter_CombinesPredicateAndProjection()
+    public async Task BuildBaseQuery_WithFilter_ReturnsMatchingDomain()
     {
         await using var f = new Fixture();
         f.Ctx.Trips.AddRange(


### PR DESCRIPTION
## Summary

- `QueryBase<TEntity,TDomain>` → `QueryBase<TEntity>`: keeps only `BuildBaseQuery()`
- `CrudBase<TEntity,TDomain>` → `CrudBase<TEntity>`: keeps `InsertAsync`, `ExecuteUpdateAsync`, `ExecuteDeleteAsync`; removes `GetByIdAsync` and projection wrappers
- `BusinessBase<TEntity,TDomain>` → `BusinessBase<TEntity>`: thin wrapper, no change in purpose
- All three Business classes and `BusinessBaseTests` updated to own their projections directly via `BuildBaseQuery().Where(...).Select(...).ToListAsync(ct)`

## Why

The class-level `TDomain` parameter locked each Business class into a single projection type and introduced wrapper methods that added no value. Projection varies per method — it belongs in the Business class, not the base.

## Test plan
- [x] All 68 tests pass
- [x] Build: 0 errors, 8 pre-existing warnings (AOP interceptors, unrelated)
- Pure refactor — no behaviour change

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)