### PR TITLE
Group 6: AddPlaceProcess — geocoding-driven place creation

### DIFF
--- a/src/TripsTracker.Business/CountryBusiness.cs
+++ b/src/TripsTracker.Business/CountryBusiness.cs
@@ -14,6 +14,12 @@ public class CountryBusiness : BusinessBase<Country>, ICountryBusiness
         => BuildBaseQuery().Select(c => new CountryDto(
             c.Id, c.IsoNumeric, c.IsoAlpha2, c.Flag, c.Name, c.Region, c.IsHome, c.IsVisited)).ToListAsync(ct);
 
+    public Task<CountryDto?> GetByIsoAlpha2Async(string isoAlpha2, CancellationToken ct = default)
+        => BuildBaseQuery()
+            .Where(c => c.IsoAlpha2 == isoAlpha2)
+            .Select(c => new CountryDto(c.Id, c.IsoNumeric, c.IsoAlpha2, c.Flag, c.Name, c.Region, c.IsHome, c.IsVisited))
+            .FirstOrDefaultAsync(ct);
+
     public async Task<CountryDto?> SetVisitedAsync(int id, bool isVisited, CancellationToken ct = default)
     {
         var rows = await ExecuteUpdateAsync(

--- a/src/TripsTracker.Business/PlaceBusiness.cs
+++ b/src/TripsTracker.Business/PlaceBusiness.cs
@@ -10,6 +10,22 @@ public class PlaceBusiness : BusinessBase<Place>, IPlaceBusiness
 {
     public PlaceBusiness(TripsTrackerDbContext context) : base(context) { }
 
+    public async Task<PlaceDto> CreateAsync(CreatePlaceDto dto, CancellationToken ct = default)
+    {
+        var place = new Place
+        {
+            Lon = dto.Lon,
+            Lat = dto.Lat,
+            CountryId = dto.CountryId,
+            City = dto.City,
+            StateAbbr = dto.StateAbbr,
+            IsHome = dto.IsHome
+        };
+        await InsertAsync(place, ct);
+        return await GetByIdAsync(place.Id, ct)
+            ?? throw new InvalidOperationException($"Failed to retrieve created place {place.Id}.");
+    }
+
     public Task<List<PlaceDto>> GetAllAsync(CancellationToken ct = default)
         => BuildBaseQuery()
             .Join(Context.Set<Country>().AsNoTracking(),

--- a/src/TripsTracker.Domain/AddPlaceDto.cs
+++ b/src/TripsTracker.Domain/AddPlaceDto.cs
@@ -1,0 +1,3 @@
+namespace TripsTracker.Domain;
+
+public record AddPlaceDto(string CityName, string CountryIsoAlpha2, bool IsHome = false);

--- a/src/TripsTracker.Domain/CreatePlaceDto.cs
+++ b/src/TripsTracker.Domain/CreatePlaceDto.cs
@@ -1,0 +1,3 @@
+namespace TripsTracker.Domain;
+
+public record CreatePlaceDto(double Lon, double Lat, int CountryId, string City, string? StateAbbr, bool IsHome);

--- a/src/TripsTracker.Functions/PlaceFunctions.cs
+++ b/src/TripsTracker.Functions/PlaceFunctions.cs
@@ -4,14 +4,36 @@ using Microsoft.Azure.Functions.Worker;
 using System.Text.Json;
 using TripsTracker.Domain;
 using TripsTracker.Interfaces.Business;
+using TripsTracker.Interfaces.Exceptions;
+using TripsTracker.Interfaces.Process;
 
 namespace TripsTracker.Functions;
 
-public class PlaceFunctions(IPlaceBusiness places)
+public class PlaceFunctions(IPlaceBusiness places, IAddPlaceProcess addPlace)
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
-    // POST /places is handled by AddPlaceProcess (Group 6 — geocoding-driven creation)
+    [Function("CreatePlace")]
+    public async Task<IActionResult> CreatePlace(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "places")] HttpRequest req,
+        CancellationToken ct)
+    {
+        var dto = await JsonSerializer.DeserializeAsync<AddPlaceDto>(req.Body, JsonOptions, ct);
+        if (dto is null) return new BadRequestObjectResult("Invalid request body.");
+        try
+        {
+            var result = await addPlace.ExecuteAsync(dto, ct);
+            return new CreatedResult($"/api/places/{result.Id}", result);
+        }
+        catch (NotFoundException ex)
+        {
+            return new NotFoundObjectResult(ex.Message);
+        }
+        catch (BusinessRuleException ex)
+        {
+            return new UnprocessableEntityObjectResult(ex.Message);
+        }
+    }
 
     [Function("UpdatePlace")]
     public async Task<IActionResult> UpdatePlace(

--- a/src/TripsTracker.Interfaces/Business/ICountryBusiness.cs
+++ b/src/TripsTracker.Interfaces/Business/ICountryBusiness.cs
@@ -5,6 +5,7 @@ namespace TripsTracker.Interfaces.Business;
 public interface ICountryBusiness
 {
     Task<List<CountryDto>> GetAllAsync(CancellationToken ct = default);
+    Task<CountryDto?> GetByIsoAlpha2Async(string isoAlpha2, CancellationToken ct = default);
     Task<CountryDto?> SetVisitedAsync(int id, bool isVisited, CancellationToken ct = default);
     Task<CountryDto?> SetHomeAsync(int id, CancellationToken ct = default);
 }

--- a/src/TripsTracker.Interfaces/Business/IPlaceBusiness.cs
+++ b/src/TripsTracker.Interfaces/Business/IPlaceBusiness.cs
@@ -5,6 +5,7 @@ namespace TripsTracker.Interfaces.Business;
 public interface IPlaceBusiness
 {
     Task<List<PlaceDto>> GetAllAsync(CancellationToken ct = default);
+    Task<PlaceDto> CreateAsync(CreatePlaceDto dto, CancellationToken ct = default);
     Task<PlaceDto?> GetByIdAsync(int id, CancellationToken ct = default);
     Task<PlaceDto?> UpdateAsync(int id, UpdatePlaceDto dto, CancellationToken ct = default);
     Task<bool> DeleteAsync(int id, CancellationToken ct = default);

--- a/src/TripsTracker.Interfaces/Process/IAddPlaceProcess.cs
+++ b/src/TripsTracker.Interfaces/Process/IAddPlaceProcess.cs
@@ -1,0 +1,8 @@
+using TripsTracker.Domain;
+
+namespace TripsTracker.Interfaces.Process;
+
+public interface IAddPlaceProcess
+{
+    Task<PlaceDto> ExecuteAsync(AddPlaceDto dto, CancellationToken ct = default);
+}

--- a/src/TripsTracker.Process/AddPlaceProcess.cs
+++ b/src/TripsTracker.Process/AddPlaceProcess.cs
@@ -1,0 +1,41 @@
+using TripsTracker.Domain;
+using TripsTracker.Interfaces.Business;
+using TripsTracker.Interfaces.Exceptions;
+using TripsTracker.Interfaces.Integration;
+using TripsTracker.Interfaces.Process;
+
+namespace TripsTracker.Process;
+
+public class AddPlaceProcess : IAddPlaceProcess
+{
+    private readonly IPlaceBusiness _places;
+    private readonly ICountryBusiness _countries;
+    private readonly INominatimService _nominatim;
+
+    public AddPlaceProcess(IPlaceBusiness places, ICountryBusiness countries, INominatimService nominatim)
+    {
+        _places = places;
+        _countries = countries;
+        _nominatim = nominatim;
+    }
+
+    public async Task<PlaceDto> ExecuteAsync(AddPlaceDto dto, CancellationToken ct = default)
+    {
+        var country = await _countries.GetByIsoAlpha2Async(dto.CountryIsoAlpha2, ct)
+            ?? throw new NotFoundException("Country", dto.CountryIsoAlpha2);
+
+        var geocoded = await _nominatim.GeocodeAsync(dto.CityName, dto.CountryIsoAlpha2, ct)
+            ?? throw new BusinessRuleException(
+                $"Could not geocode '{dto.CityName}' in {country.Name}. Try a different city name.",
+                "GEOCODING_FAILED");
+
+        var place = await _places.CreateAsync(
+            new CreatePlaceDto(geocoded.Lon, geocoded.Lat, country.Id, geocoded.City, geocoded.StateAbbr, dto.IsHome),
+            ct);
+
+        if (!country.IsVisited && !country.IsHome)
+            await _countries.SetVisitedAsync(country.Id, true, ct);
+
+        return place;
+    }
+}


### PR DESCRIPTION
## Summary
- New `POST /api/places` endpoint that creates a place via Nominatim geocoding
- `AddPlaceProcess` coordinates: country lookup → geocode → place creation → mark country visited
- `CreatePlaceDto` carries geocoding-resolved data from Process to PlaceBusiness
- `IPlaceBusiness.CreateAsync` and `ICountryBusiness.GetByIsoAlpha2Async` added
- Country is marked visited automatically when first place is added there

## Why
Coordinates from user entry are error-prone. Nominatim provides authoritative lat/lon, canonical city name, and state code from a simple city name + country hint. This is the integration architecture established in Group 2.

## Test plan
- [ ] Build passes
- [ ] 72 tests pass
- [ ] `POST /api/places` with `{"cityName":"Rio de Janeiro","countryIsoAlpha2":"BR","isHome":false}` creates a place with correct coords and stateAbbr
- [ ] Unknown country returns 404
- [ ] Unknown city returns 422

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)