### PR TITLE
Fix: SQL setup WITH OBJECT_ID for new environments

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -52,7 +52,9 @@ jobs:
             --query properties.outputs \
             --output json)
           swa_token=$(echo "$output" | jq -r '.staticWebAppDeploymentToken.value')
+          func_principal_id=$(echo "$output" | jq -r '.functionAppPrincipalId.value')
           echo "swa_token=$swa_token" >> $GITHUB_OUTPUT
+          echo "func_principal_id=$func_principal_id" >> $GITHUB_OUTPUT
 
       # ── Database: firewall + access grants + migrations ───────────────────────
 
@@ -86,6 +88,7 @@ jobs:
             --authentication-method ActiveDirectoryDefault \
             -b \
             -v FunctionAppName="$FUNCTION_APP_NAME" \
+            -v FunctionAppPrincipalId="${{ steps.bicep.outputs.func_principal_id }}" \
             -i infra/sql/setup.sql
 
       - name: Setup .NET

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -53,7 +53,9 @@ jobs:
             --query properties.outputs \
             --output json)
           swa_token=$(echo "$output" | jq -r '.staticWebAppDeploymentToken.value')
+          func_principal_id=$(echo "$output" | jq -r '.functionAppPrincipalId.value')
           echo "swa_token=$swa_token" >> $GITHUB_OUTPUT
+          echo "func_principal_id=$func_principal_id" >> $GITHUB_OUTPUT
 
       # ── Database: firewall + access grants + migrations ───────────────────────
 
@@ -87,6 +89,7 @@ jobs:
             --authentication-method ActiveDirectoryDefault \
             -b \
             -v FunctionAppName="$FUNCTION_APP_NAME" \
+            -v FunctionAppPrincipalId="${{ steps.bicep.outputs.func_principal_id }}" \
             -i infra/sql/setup.sql
 
       - name: Setup .NET

--- a/infra/sql/setup.sql
+++ b/infra/sql/setup.sql
@@ -1,9 +1,10 @@
 -- Idempotent SQL setup — run after every Bicep deployment
 -- Requires: SQL Server Entra admin configured + SQL Server system-assigned identity enabled
+-- Uses WITH OBJECT_ID to bypass Directory Readers requirement on new servers
 
 -- Function App managed identity: runtime data access
 IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'$(FunctionAppName)')
-    CREATE USER [$(FunctionAppName)] FROM EXTERNAL PROVIDER;
+    CREATE USER [$(FunctionAppName)] FROM EXTERNAL PROVIDER WITH OBJECT_ID = '$(FunctionAppPrincipalId)';
 ALTER ROLE db_datareader ADD MEMBER [$(FunctionAppName)];
 ALTER ROLE db_datawriter ADD MEMBER [$(FunctionAppName)];
 ALTER ROLE db_ddladmin ADD MEMBER [$(FunctionAppName)];


### PR DESCRIPTION
## Summary
- Restores `WITH OBJECT_ID` syntax in `setup.sql` to bypass Directory Readers requirement
- Passes `functionAppPrincipalId` from Bicep output to sqlcmd in both dev and test workflows
- Idempotent for DEV (user already exists, CREATE is skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)