### PR TITLE
Fix: assign Directory Readers to SQL Server identity on first deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -52,9 +52,7 @@ jobs:
             --query properties.outputs \
             --output json)
           swa_token=$(echo "$output" | jq -r '.staticWebAppDeploymentToken.value')
-          func_principal_id=$(echo "$output" | jq -r '.functionAppPrincipalId.value')
           echo "swa_token=$swa_token" >> $GITHUB_OUTPUT
-          echo "func_principal_id=$func_principal_id" >> $GITHUB_OUTPUT
 
       # ── Database: firewall + access grants + migrations ───────────────────────
 
@@ -88,7 +86,6 @@ jobs:
             --authentication-method ActiveDirectoryDefault \
             -b \
             -v FunctionAppName="$FUNCTION_APP_NAME" \
-            -v FunctionAppPrincipalId="${{ steps.bicep.outputs.func_principal_id }}" \
             -i infra/sql/setup.sql
 
       - name: Setup .NET

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -18,6 +18,7 @@ env:
   SQL_DATABASE: TripsTracker
   FUNCTION_APP_NAME: func-tripstracker-test-ttk
   FUNCTION_APP_URL: https://func-tripstracker-test-ttk.azurewebsites.net/api
+  DIRECTORY_READERS_ROLE_ID: 88d8e3e3-8f55-4a1e-953a-9b9898b8876b
 
 jobs:
   deploy:
@@ -53,11 +54,30 @@ jobs:
             --query properties.outputs \
             --output json)
           swa_token=$(echo "$output" | jq -r '.staticWebAppDeploymentToken.value')
-          func_principal_id=$(echo "$output" | jq -r '.functionAppPrincipalId.value')
+          sql_server_identity_id=$(echo "$output" | jq -r '.sqlServerIdentityPrincipalId.value')
           echo "swa_token=$swa_token" >> $GITHUB_OUTPUT
-          echo "func_principal_id=$func_principal_id" >> $GITHUB_OUTPUT
+          echo "sql_server_identity_id=$sql_server_identity_id" >> $GITHUB_OUTPUT
 
       # ── Database: firewall + access grants + migrations ───────────────────────
+
+      - name: Assign Directory Readers to SQL server identity (idempotent)
+        run: |
+          SQL_IDENTITY="${{ steps.bicep.outputs.sql_server_identity_id }}"
+          echo "SQL server identity: $SQL_IDENTITY"
+
+          EXISTING=$(az rest --method GET \
+            --url "https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignments?\$filter=principalId eq '$SQL_IDENTITY' and roleDefinitionId eq '$DIRECTORY_READERS_ROLE_ID'" \
+            --query 'value[0].id' -o tsv 2>/dev/null || true)
+
+          if [ -z "$EXISTING" ] || [ "$EXISTING" = "None" ]; then
+            az rest --method POST \
+              --url "https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignments" \
+              --body "{\"@odata.type\":\"#microsoft.graph.unifiedRoleAssignment\",\"roleDefinitionId\":\"$DIRECTORY_READERS_ROLE_ID\",\"principalId\":\"$SQL_IDENTITY\",\"directoryScopeId\":\"/\"}"
+            echo "Directory Readers assigned — waiting 30s for Entra propagation"
+            sleep 30
+          else
+            echo "Directory Readers already assigned (idempotent)"
+          fi
 
       - name: Open SQL firewall for GitHub runner
         run: |
@@ -89,7 +109,6 @@ jobs:
             --authentication-method ActiveDirectoryDefault \
             -b \
             -v FunctionAppName="$FUNCTION_APP_NAME" \
-            -v FunctionAppPrincipalId="${{ steps.bicep.outputs.func_principal_id }}" \
             -i infra/sql/setup.sql
 
       - name: Setup .NET

--- a/infra/sql/setup.sql
+++ b/infra/sql/setup.sql
@@ -1,10 +1,10 @@
 -- Idempotent SQL setup — run after every Bicep deployment
 -- Requires: SQL Server Entra admin configured + SQL Server system-assigned identity enabled
--- Uses WITH OBJECT_ID to bypass Directory Readers requirement on new servers
+-- Directory Readers role assigned to SQL Server identity by the pipeline before this runs
 
 -- Function App managed identity: runtime data access
 IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'$(FunctionAppName)')
-    CREATE USER [$(FunctionAppName)] FROM EXTERNAL PROVIDER WITH OBJECT_ID = '$(FunctionAppPrincipalId)';
+    CREATE USER [$(FunctionAppName)] FROM EXTERNAL PROVIDER;
 ALTER ROLE db_datareader ADD MEMBER [$(FunctionAppName)];
 ALTER ROLE db_datawriter ADD MEMBER [$(FunctionAppName)];
 ALTER ROLE db_ddladmin ADD MEMBER [$(FunctionAppName)];


### PR DESCRIPTION
## Summary
- Adds idempotent Directory Readers assignment step to the test pipeline
- Required for CREATE USER FROM EXTERNAL PROVIDER on a brand-new SQL server
- Idempotent: skips if already assigned (safe to run on every deploy)
- Reverts deploy-dev.yml to original state

🤖 Generated with [Claude Code](https://claude.com/claude-code)