### PR TITLE
Stage 7.5: Cross-stage border fixes (RDP simplification + blob cache)

### DIFF
--- a/docs/architecture-callflow.html
+++ b/docs/architecture-callflow.html
@@ -83,7 +83,7 @@
 </head>
 <body>
 <h1>TripsTracker — Architecture Overview</h1>
-<h2>Layers · components · operation flows &nbsp;·&nbsp; 2026-04-30 (Stage 4 — stories #47, #48, #84 — multi-user · profiles · state borders)</h2>
+<h2>Layers · components · operation flows &nbsp;·&nbsp; 2026-05-26 (Stage 4 + Stage 7.5 — multi-user · profiles · state borders · RDP simplification · blob border cache)</h2>
 
 <svg viewBox="0 0 1560 810" xmlns="http://www.w3.org/2000/svg"
      font-family="'Segoe UI', Consolas, sans-serif">
@@ -358,6 +358,7 @@
   <div class="li"><div class="lc" style="background:#3fb950"></div> Read data — GET endpoints</div>
   <div class="li"><div class="lc" style="background:#f0883e"></div> Update country — PUT</div>
   <div class="li"><div class="lc" style="background:#e3b341"></div>User profile — GET/PUT /api/me · display name · home country · state border prefs</div>
+  <div class="li"><div class="lc" style="background:#2dd4bf"></div>Get State Borders GeoJSON — cache-first (Stage 7.5): blob cache check → geoBoundaries fetch + normalise + RDP simplify → cache write (silent fail)</div>
   <div class="li" style="color:#475569">- - - dashed arrow: conditional flow &nbsp;&nbsp; - - - dashed oval: SQL VIEW — no write API</div>
 </div>
 
@@ -905,6 +906,75 @@
               <span style="color:#58a6ff">→</span> SELECT from Users WHERE Email = @email (GET)<br>
               <span style="color:#58a6ff">→</span> ExecuteUpdateAsync SET DisplayName = @displayName (PUT)<br>
               <span style="color:#3fb950">←</span> <code style="background:#1a2236;padding:1px 4px;border-radius:3px;font-size:0.72rem">UserDto { Id, Email, DisplayName, CreatedAt }</code>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="proc-card">
+      <div class="proc-card-header" style="background:#0a2222; color:#2dd4bf">
+        <span style="width:10px;height:10px;border-radius:50%;background:#2dd4bf;display:inline-block"></span>
+        Get State Borders GeoJSON (Stage 4 / Stage 7.5 cache-first)
+      </div>
+      <div style="padding:14px 18px; display:flex; flex-direction:column; gap:14px;">
+        <div style="display:flex;gap:12px;align-items:flex-start">
+          <div style="min-width:22px;height:22px;border-radius:50%;background:#2dd4bf;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:bold;color:#000;flex-shrink:0">1</div>
+          <div>
+            <div style="font-size:0.78rem;font-weight:600;color:#e2e8f0">WorldMap / MapPage <span style="background:#261408;color:#f0883e;border:1px solid #3a2010;border-radius:3px;padding:1px 5px;font-size:0.68rem">Frontend</span></div>
+            <div style="font-size:0.75rem;color:#94a3b8;margin-top:4px;line-height:1.6">
+              On mount or border toggle — <code style="background:#1a2236;padding:1px 4px;border-radius:3px;font-size:0.72rem">useBorderLoader</code> hook fires per country with ShowStateBorders=true<br>
+              <span style="color:#58a6ff">→</span> <code style="background:#1a2236;padding:1px 4px;border-radius:3px;font-size:0.72rem">GET /api/countries/{id}/borders</code>
+            </div>
+          </div>
+        </div>
+        <div style="display:flex;gap:12px;align-items:flex-start">
+          <div style="min-width:22px;height:22px;border-radius:50%;background:#2dd4bf;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:bold;color:#000;flex-shrink:0">2</div>
+          <div>
+            <div style="font-size:0.78rem;font-weight:600;color:#e2e8f0">CountryFunctions → CountriesProcess <span style="background:#19122a;color:#d2a8ff;border:1px solid #2d1f4a;border-radius:3px;padding:1px 5px;font-size:0.68rem">Functions / Process</span></div>
+            <div style="font-size:0.75rem;color:#94a3b8;margin-top:4px;line-height:1.6">
+              <span style="color:#58a6ff">→</span> <code style="background:#1a2236;padding:1px 4px;border-radius:3px;font-size:0.72rem">CountriesProcess.GetBordersAsync(countryId)</code>
+            </div>
+          </div>
+        </div>
+        <div style="display:flex;gap:12px;align-items:flex-start">
+          <div style="min-width:22px;height:22px;border-radius:50%;background:#2dd4bf;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:bold;color:#000;flex-shrink:0">3</div>
+          <div>
+            <div style="font-size:0.78rem;font-weight:600;color:#e2e8f0">CountriesProcess — IsoAlpha3 lookup <span style="background:#0a1a30;color:#79c0ff;border:1px solid #1a3a5f;border-radius:3px;padding:1px 5px;font-size:0.68rem">Process → Business</span></div>
+            <div style="font-size:0.75rem;color:#94a3b8;margin-top:4px;line-height:1.6">
+              <span style="color:#58a6ff">→</span> <code style="background:#1a2236;padding:1px 4px;border-radius:3px;font-size:0.72rem">CountryBusiness.GetIsoAlpha3Async(countryId)</code> ← isoAlpha3<br>
+              <span style="font-style:italic;color:#64748b">(cond) null isoAlpha3 → return null immediately (no GeoJSON available)</span>
+            </div>
+          </div>
+        </div>
+        <div style="display:flex;gap:12px;align-items:flex-start">
+          <div style="min-width:22px;height:22px;border-radius:50%;background:#2dd4bf;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:bold;color:#000;flex-shrink:0">3b</div>
+          <div>
+            <div style="font-size:0.78rem;font-weight:600;color:#e2e8f0">CountriesProcess — blob cache check <span style="background:#131924;color:#94a3b8;border:1px solid #1e2533;border-radius:3px;padding:1px 5px;font-size:0.68rem">Stage 7.5</span></div>
+            <div style="font-size:0.75rem;color:#94a3b8;margin-top:4px;line-height:1.6">
+              <span style="color:#58a6ff">→</span> <code style="background:#1a2236;padding:1px 4px;border-radius:3px;font-size:0.72rem">IBorderCacheService.GetAsync(isoAlpha3)</code><br>
+              <span style="font-style:italic;color:#64748b">(cond) cache hit → return json immediately; skip steps 4–5</span>
+            </div>
+          </div>
+        </div>
+        <div style="display:flex;gap:12px;align-items:flex-start">
+          <div style="min-width:22px;height:22px;border-radius:50%;background:#2dd4bf;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:bold;color:#000;flex-shrink:0">4</div>
+          <div>
+            <div style="font-size:0.78rem;font-weight:600;color:#e2e8f0">GeoBoundariesService <span style="background:#131924;color:#94a3b8;border:1px solid #1e2533;border-radius:3px;padding:1px 5px;font-size:0.68rem">Integration</span></div>
+            <div style="font-size:0.75rem;color:#94a3b8;margin-top:4px;line-height:1.6">
+              <span style="color:#58a6ff">→</span> GET geoboundaries.org metadata → download GeoJSON bytes<br>
+              → NormaliseGeoJson: remap shapeISO→ISO_1, shapeName→NAME_1; reverse ring order CW→CCW; RDP simplify (ε=0.01)<br>
+              <span style="color:#3fb950">←</span> GADM-format GeoJSON string
+            </div>
+          </div>
+        </div>
+        <div style="display:flex;gap:12px;align-items:flex-start">
+          <div style="min-width:22px;height:22px;border-radius:50%;background:#2dd4bf;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:bold;color:#000;flex-shrink:0">5b</div>
+          <div>
+            <div style="font-size:0.78rem;font-weight:600;color:#e2e8f0">CountriesProcess — blob cache write <span style="background:#131924;color:#94a3b8;border:1px solid #1e2533;border-radius:3px;padding:1px 5px;font-size:0.68rem">Stage 7.5</span></div>
+            <div style="font-size:0.75rem;color:#94a3b8;margin-top:4px;line-height:1.6">
+              <span style="font-style:italic;color:#64748b">(cond) if json not null:</span> <code style="background:#1a2236;padding:1px 4px;border-radius:3px;font-size:0.72rem">IBorderCacheService.SetAsync(isoAlpha3, json)</code><br>
+              <span style="font-style:italic;color:#64748b">blob write failure is caught and logged silently — json returned regardless</span>
             </div>
           </div>
         </div>

--- a/docs/architecture-diagram.html
+++ b/docs/architecture-diagram.html
@@ -35,6 +35,8 @@ flowchart TB
         direction LR
         G1["NominatimGeocodingService\n: INominatimService\nGeocodeAsync(city, countryCode) → Nominatim\nSuggestCitiesAsync(query, country) → Photon API\n(photon.komoot.io — prefix autocomplete)"]
         G2["HttpClient (named)\nNominatimOptions\n(BaseUrl · UserAgent · Timeout)"]
+        G3["GeoBoundariesService\n: IGeoBoundariesService\nGetBordersAsync(isoAlpha3) → GeoJSON string\n(fetch geoboundaries.org · normalise · RDP simplify ε=0.01)"]
+        G4["BlobBorderCacheService\n: IBorderCacheService (Stage 7.5)\nGetAsync(isoAlpha3) → string?\nSetAsync(isoAlpha3, json) → blob write (silent fail)"]
     end
 
     subgraph BUSINESS["🧠 Business Layer — TripsTracker.Business"]
@@ -99,7 +101,7 @@ flowchart TB
     <div class="legend-item">DbContext registered as Scoped — one per Function invocation; enables IQueryable composition + safe sequential writes</div>
     <div class="legend-item">Base classes (BusinessBase / CrudBase / QueryBase) live in Data project — Business references Data for inheritance. TDomain generic removed; projection is Business responsibility.</div>
     <div class="legend-item">Process layer never references Data or Integration directly — composes Business interfaces only</div>
-    <div class="legend-item">Integration layer holds all external HTTP calls. NominatimGeocodingService uses two APIs: Nominatim for geocoding (GeocodeAsync) and Photon (photon.komoot.io) for prefix autocomplete (SuggestCitiesAsync). Wrapped by GeocodingBusiness — Process calls IGeocodingBusiness, never INominatimService directly.</div>
+    <div class="legend-item">Integration layer holds all external HTTP calls. NominatimGeocodingService uses two APIs: Nominatim for geocoding (GeocodeAsync) and Photon (photon.komoot.io) for prefix autocomplete (SuggestCitiesAsync). Wrapped by GeocodingBusiness — Process calls IGeocodingBusiness, never INominatimService directly. GeoBoundariesService (Stage 4) fetches sub-national boundary GeoJSON; BlobBorderCacheService (Stage 7.5) caches result in Azure Blob Storage — cache-first in CountriesProcess.GetBordersAsync.</div>
     <div class="legend-item">VisitedStates is a SQL VIEW — no entity class, no write API. VisitedStateBusiness reads it via a raw SQL query projection.</div>
   </div>
 </div>

--- a/src/TripsTracker.Functions/Program.cs
+++ b/src/TripsTracker.Functions/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddDatabaseContext<TripsTrackerDbContext>(dbOptions);
 
 // Register typed HTTP clients for integration services (before Scrutor so TryAdd skips them)
 builder.Services.AddIntegrationHttpClients();
+builder.Services.AddBorderCacheService(builder.Configuration);
 
 // IHttpContextAccessor — required by JwtValidationMiddleware to read the Bearer token
 builder.Services.AddHttpContextAccessor();

--- a/src/TripsTracker.Integration/BlobBorderCacheService.cs
+++ b/src/TripsTracker.Integration/BlobBorderCacheService.cs
@@ -1,0 +1,41 @@
+using Azure;
+using Azure.Storage.Blobs;
+using System.Text;
+using TripsTracker.Interfaces.Integration;
+
+namespace TripsTracker.Integration;
+
+public class BlobBorderCacheService : IBorderCacheService
+{
+    private readonly BlobServiceClient _client;
+    private const string ContainerName = "borders";
+
+    public BlobBorderCacheService(BlobServiceClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<string?> GetAsync(string isoAlpha3, CancellationToken ct = default)
+    {
+        var container = _client.GetBlobContainerClient(ContainerName);
+        var blob = container.GetBlobClient($"{isoAlpha3}.json");
+        try
+        {
+            var response = await blob.DownloadContentAsync(ct);
+            return response.Value.Content.ToString();
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    public async Task SetAsync(string isoAlpha3, string json, CancellationToken ct = default)
+    {
+        var container = _client.GetBlobContainerClient(ContainerName);
+        await container.CreateIfNotExistsAsync(cancellationToken: ct);
+        var blob = container.GetBlobClient($"{isoAlpha3}.json");
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        await blob.UploadAsync(ms, overwrite: true, cancellationToken: ct);
+    }
+}

--- a/src/TripsTracker.Integration/GeoBoundariesService.cs
+++ b/src/TripsTracker.Integration/GeoBoundariesService.cs
@@ -143,6 +143,8 @@ public class GeoBoundariesService : IGeoBoundariesService
         writer.WriteEndObject();
     }
 
+    private const double SimplificationTolerance = 0.01;
+
     private static void WriteRewindedPolygon(Utf8JsonWriter writer, JsonElement polygon)
     {
         writer.WriteStartArray();
@@ -150,12 +152,55 @@ public class GeoBoundariesService : IGeoBoundariesService
         {
             var positions = ring.EnumerateArray().ToList();
             positions.Reverse();
+            var simplified = RdpSimplify(positions, SimplificationTolerance);
+            if (simplified.Count < 4) simplified = positions;
             writer.WriteStartArray();
-            foreach (var pos in positions)
+            foreach (var pos in simplified)
                 pos.WriteTo(writer);
             writer.WriteEndArray();
         }
         writer.WriteEndArray();
+    }
+
+    private static List<JsonElement> RdpSimplify(List<JsonElement> points, double tolerance)
+    {
+        if (points.Count < 3) return points;
+        var keep = new bool[points.Count];
+        keep[0] = true;
+        keep[points.Count - 1] = true;
+        RdpRecurse(points, 0, points.Count - 1, tolerance, keep);
+        return points.Where((_, i) => keep[i]).ToList();
+    }
+
+    private static void RdpRecurse(List<JsonElement> points, int start, int end, double tolerance, bool[] keep)
+    {
+        if (end <= start + 1) return;
+        double maxDist = 0;
+        int maxIdx = start;
+        for (int i = start + 1; i < end; i++)
+        {
+            var d = PerpendicularDistance(points[i], points[start], points[end]);
+            if (d > maxDist) { maxDist = d; maxIdx = i; }
+        }
+        if (maxDist > tolerance)
+        {
+            keep[maxIdx] = true;
+            RdpRecurse(points, start, maxIdx, tolerance, keep);
+            RdpRecurse(points, maxIdx, end, tolerance, keep);
+        }
+    }
+
+    private static double PerpendicularDistance(JsonElement point, JsonElement lineStart, JsonElement lineEnd)
+    {
+        double x = point[0].GetDouble(), y = point[1].GetDouble();
+        double x1 = lineStart[0].GetDouble(), y1 = lineStart[1].GetDouble();
+        double x2 = lineEnd[0].GetDouble(), y2 = lineEnd[1].GetDouble();
+        double dx = x2 - x1, dy = y2 - y1;
+        if (dx == 0 && dy == 0)
+            return Math.Sqrt((x - x1) * (x - x1) + (y - y1) * (y - y1));
+        double t = ((x - x1) * dx + (y - y1) * dy) / (dx * dx + dy * dy);
+        double px = x1 + t * dx - x, py = y1 + t * dy - y;
+        return Math.Sqrt(px * px + py * py);
     }
 
     private sealed class GeoBoundariesMetadata

--- a/src/TripsTracker.Integration/Registration/IntegrationRegistrationExtensions.cs
+++ b/src/TripsTracker.Integration/Registration/IntegrationRegistrationExtensions.cs
@@ -1,3 +1,5 @@
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using TripsTracker.Interfaces.Configuration;
@@ -27,6 +29,18 @@ public static class IntegrationRegistrationExtensions
             client.Timeout = TimeSpan.FromSeconds(30);
         });
 
+        return services;
+    }
+
+    /// <summary>
+    /// Registers BlobServiceClient and IBorderCacheService for the server-side border GeoJSON cache.
+    /// Must be called before Scrutor's AddScopedApplicationServices so TryAdd skips these.
+    /// </summary>
+    public static IServiceCollection AddBorderCacheService(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration["BlobStorage:ConnectionString"];
+        services.AddSingleton(new BlobServiceClient(connectionString));
+        services.AddScoped<IBorderCacheService, BlobBorderCacheService>();
         return services;
     }
 }

--- a/src/TripsTracker.Integration/TripsTracker.Integration.csproj
+++ b/src/TripsTracker.Integration/TripsTracker.Integration.csproj
@@ -6,6 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
   </ItemGroup>
 

--- a/src/TripsTracker.Interfaces/Integration/IBorderCacheService.cs
+++ b/src/TripsTracker.Interfaces/Integration/IBorderCacheService.cs
@@ -1,0 +1,7 @@
+namespace TripsTracker.Interfaces.Integration;
+
+public interface IBorderCacheService
+{
+    Task<string?> GetAsync(string isoAlpha3, CancellationToken ct = default);
+    Task SetAsync(string isoAlpha3, string json, CancellationToken ct = default);
+}

--- a/src/TripsTracker.Process/CountriesProcess.cs
+++ b/src/TripsTracker.Process/CountriesProcess.cs
@@ -8,17 +8,27 @@ public class CountriesProcess : ICountriesProcess
 {
     private readonly ICountryBusiness _countries;
     private readonly IGeoBoundariesService _geoBoundaries;
+    private readonly IBorderCacheService _borderCache;
 
-    public CountriesProcess(ICountryBusiness countries, IGeoBoundariesService geoBoundaries)
+    public CountriesProcess(ICountryBusiness countries, IGeoBoundariesService geoBoundaries, IBorderCacheService borderCache)
     {
         _countries = countries;
         _geoBoundaries = geoBoundaries;
+        _borderCache = borderCache;
     }
 
     public async Task<string?> GetBordersAsync(int countryId, CancellationToken ct = default)
     {
         var isoAlpha3 = await _countries.GetIsoAlpha3Async(countryId, ct);
         if (string.IsNullOrEmpty(isoAlpha3)) return null;
-        return await _geoBoundaries.GetBordersAsync(isoAlpha3, ct);
+
+        var cached = await _borderCache.GetAsync(isoAlpha3, ct);
+        if (cached != null) return cached;
+
+        var json = await _geoBoundaries.GetBordersAsync(isoAlpha3, ct);
+        if (json != null)
+            await _borderCache.SetAsync(isoAlpha3, json, ct);
+
+        return json;
     }
 }

--- a/src/TripsTracker.Process/CountriesProcess.cs
+++ b/src/TripsTracker.Process/CountriesProcess.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using TripsTracker.Interfaces.Business;
 using TripsTracker.Interfaces.Integration;
 using TripsTracker.Interfaces.Process;
@@ -9,12 +10,14 @@ public class CountriesProcess : ICountriesProcess
     private readonly ICountryBusiness _countries;
     private readonly IGeoBoundariesService _geoBoundaries;
     private readonly IBorderCacheService _borderCache;
+    private readonly ILogger<CountriesProcess> _logger;
 
-    public CountriesProcess(ICountryBusiness countries, IGeoBoundariesService geoBoundaries, IBorderCacheService borderCache)
+    public CountriesProcess(ICountryBusiness countries, IGeoBoundariesService geoBoundaries, IBorderCacheService borderCache, ILogger<CountriesProcess> logger)
     {
         _countries = countries;
         _geoBoundaries = geoBoundaries;
         _borderCache = borderCache;
+        _logger = logger;
     }
 
     public async Task<string?> GetBordersAsync(int countryId, CancellationToken ct = default)
@@ -27,7 +30,16 @@ public class CountriesProcess : ICountriesProcess
 
         var json = await _geoBoundaries.GetBordersAsync(isoAlpha3, ct);
         if (json != null)
-            await _borderCache.SetAsync(isoAlpha3, json, ct);
+        {
+            try
+            {
+                await _borderCache.SetAsync(isoAlpha3, json, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Border cache write failed for {IsoAlpha3} — returning GeoJSON without caching", isoAlpha3);
+            }
+        }
 
         return json;
     }

--- a/src/TripsTracker.Process/TripsTracker.Process.csproj
+++ b/src/TripsTracker.Process/TripsTracker.Process.csproj
@@ -5,6 +5,10 @@
     <ProjectReference Include="..\TripsTracker.Domain\TripsTracker.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/TripsTracker.Tests/Process/CountriesProcessTests.cs
+++ b/tests/TripsTracker.Tests/Process/CountriesProcessTests.cs
@@ -1,6 +1,7 @@
 using Azure.Storage.Blobs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.Net;
 using TripsTracker.Business;
 using TripsTracker.Data;
@@ -19,7 +20,7 @@ public class CountriesProcessTests
     private static BlobServiceClient _blobClient = null!;
 
     [ClassInitialize]
-    public static void ClassInitialize(TestContext _)
+    public static async Task ClassInitialize(TestContext _)
     {
         var config = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json", optional: false)
@@ -32,6 +33,10 @@ public class CountriesProcessTests
             .Options;
 
         _blobClient = new BlobServiceClient("UseDevelopmentStorage=true");
+
+        // Clean up any leftover test countries from prior failed runs
+        await using var ctx = new TripsTrackerDbContext(_options);
+        await ctx.Set<Country>().Where(c => c.IsoNumeric >= 90000).ExecuteDeleteAsync();
     }
 
     private sealed class FakeUserContext(int userId) : TripsTracker.Interfaces.IUserContext
@@ -50,6 +55,8 @@ public class CountriesProcessTests
     private const string SampleGeoJson = """{"type":"FeatureCollection","features":[]}""";
     private const string MetadataJson = """{"gjDownloadURL":"https://cdn.example.com/test.geojson"}""";
 
+    private static int _isoNumericSeed = 90000;
+
     private sealed class Fixture : IAsyncDisposable
     {
         public TripsTrackerDbContext Ctx { get; }
@@ -64,14 +71,14 @@ public class CountriesProcessTests
             var http = new HttpClient(new FakeHandler(respond));
             var geoBoundaries = new GeoBoundariesService(http);
             var borderCache = new BlobBorderCacheService(_blobClient);
-            return new CountriesProcess(countries, geoBoundaries, borderCache);
+            return new CountriesProcess(countries, geoBoundaries, borderCache, NullLogger<CountriesProcess>.Instance);
         }
 
         public async Task<Country> AddCountryAsync(string? isoAlpha3)
         {
             var country = new Country
             {
-                IsoNumeric = 99999,
+                IsoNumeric = Interlocked.Increment(ref _isoNumericSeed),
                 IsoAlpha2 = "XX",
                 IsoAlpha3 = isoAlpha3,
                 Flag = "🏳",
@@ -159,5 +166,35 @@ public class CountriesProcessTests
         Assert.IsNotNull(result);
         Assert.IsTrue(result.Contains("FeatureCollection"));
         Assert.IsFalse(geoBoundariesCalled, "GeoBoundaries must not be called when cache is populated");
+    }
+
+    [TestMethod]
+    public async Task GetBordersAsync_SimplifiesPolygon_WhenRingHasCollinearPoints()
+    {
+        // Ring has 6 points; (0.5,0) is collinear with (0,0) and (1,0).
+        // RDP simplification (epsilon=0.01) should remove it → output ring has 5 points.
+        const string collinearGeoJson = """
+            {"type":"FeatureCollection","features":[{"type":"Feature","properties":{"shapeISO":"XR1-01","shapeName":"Test Region"},"geometry":{"type":"Polygon","coordinates":[[[0,0],[0.5,0],[1,0],[1,1],[0,1],[0,0]]]}}]}
+            """;
+
+        await using var f = new Fixture();
+        var country = await f.AddCountryAsync("XR1");
+        f.TrackBlob("XR1.json");
+        var sut = f.Build(req =>
+            req.RequestUri!.AbsoluteUri.Contains("geoboundaries.org")
+                ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(MetadataJson) }
+                : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(collinearGeoJson) });
+
+        var result = await sut.GetBordersAsync(country.Id);
+
+        Assert.IsNotNull(result);
+        using var doc = System.Text.Json.JsonDocument.Parse(result);
+        var ring = doc.RootElement
+            .GetProperty("features")[0]
+            .GetProperty("geometry")
+            .GetProperty("coordinates")[0];
+
+        Assert.IsTrue(ring.GetArrayLength() < 6,
+            $"Expected RDP to reduce collinear ring below 6 points, got {ring.GetArrayLength()}");
     }
 }

--- a/tests/TripsTracker.Tests/Process/CountriesProcessTests.cs
+++ b/tests/TripsTracker.Tests/Process/CountriesProcessTests.cs
@@ -1,65 +1,163 @@
-using Moq;
-using TripsTracker.Interfaces.Business;
-using TripsTracker.Interfaces.Integration;
+using Azure.Storage.Blobs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using System.Net;
+using TripsTracker.Business;
+using TripsTracker.Data;
+using TripsTracker.Data.Entities;
+using TripsTracker.Integration;
+using TripsTracker.Interfaces.Configuration;
 using TripsTracker.Process;
 
 namespace TripsTracker.Tests.Process;
 
 [TestClass]
+[DoNotParallelize]
 public class CountriesProcessTests
 {
+    private static DbContextOptions<TripsTrackerDbContext> _options = null!;
+    private static BlobServiceClient _blobClient = null!;
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext _)
+    {
+        var config = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile("appsettings.local.json", optional: true)
+            .Build();
+
+        var dbOpts = config.GetSection(DatabaseOptions.SectionName).Get<DatabaseOptions>()!;
+        _options = new DbContextOptionsBuilder<TripsTrackerDbContext>()
+            .UseSqlServer(dbOpts.ConnectionString)
+            .Options;
+
+        _blobClient = new BlobServiceClient("UseDevelopmentStorage=true");
+    }
+
+    private sealed class FakeUserContext(int userId) : TripsTracker.Interfaces.IUserContext
+    {
+        public int? UserId => userId;
+        public string? Email => null;
+        public bool IsAuthenticated => true;
+    }
+
+    private sealed class FakeHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(respond(request));
+    }
+
     private const string SampleGeoJson = """{"type":"FeatureCollection","features":[]}""";
+    private const string MetadataJson = """{"gjDownloadURL":"https://cdn.example.com/test.geojson"}""";
+
+    private sealed class Fixture : IAsyncDisposable
+    {
+        public TripsTrackerDbContext Ctx { get; }
+        private readonly List<int> _countryIds = [];
+        private readonly List<string> _blobNames = [];
+
+        public Fixture() => Ctx = new TripsTrackerDbContext(_options);
+
+        public CountriesProcess Build(Func<HttpRequestMessage, HttpResponseMessage> respond)
+        {
+            var countries = new CountryBusiness(Ctx, new FakeUserContext(1));
+            var http = new HttpClient(new FakeHandler(respond));
+            var geoBoundaries = new GeoBoundariesService(http);
+            var borderCache = new BlobBorderCacheService(_blobClient);
+            return new CountriesProcess(countries, geoBoundaries, borderCache);
+        }
+
+        public async Task<Country> AddCountryAsync(string? isoAlpha3)
+        {
+            var country = new Country
+            {
+                IsoNumeric = 99999,
+                IsoAlpha2 = "XX",
+                IsoAlpha3 = isoAlpha3,
+                Flag = "🏳",
+                Name = $"Test-{Guid.NewGuid():N}",
+                Region = "Test",
+            };
+            Ctx.Set<Country>().Add(country);
+            await Ctx.SaveChangesAsync();
+            _countryIds.Add(country.Id);
+            return country;
+        }
+
+        public void TrackBlob(string blobName) => _blobNames.Add(blobName);
+
+        public async ValueTask DisposeAsync()
+        {
+            var container = _blobClient.GetBlobContainerClient("borders");
+            foreach (var name in _blobNames)
+                await container.GetBlobClient(name).DeleteIfExistsAsync();
+
+            if (_countryIds.Count > 0)
+                await Ctx.Set<Country>().Where(c => _countryIds.Contains(c.Id)).ExecuteDeleteAsync();
+            await Ctx.DisposeAsync();
+        }
+    }
 
     [TestMethod]
     public async Task GetBordersAsync_ReturnsGeoJson_WhenCountryHasIsoAlpha3()
     {
-        var countries = new Mock<ICountryBusiness>();
-        var geoBoundaries = new Mock<IGeoBoundariesService>();
+        await using var f = new Fixture();
+        var country = await f.AddCountryAsync("XA1");
+        f.TrackBlob("XA1.json");
+        var sut = f.Build(req =>
+            req.RequestUri!.AbsoluteUri.Contains("geoboundaries.org")
+                ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(MetadataJson) }
+                : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(SampleGeoJson) });
 
-        countries.Setup(c => c.GetIsoAlpha3Async(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync("DEU");
-        geoBoundaries.Setup(g => g.GetBordersAsync("DEU", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(SampleGeoJson);
+        var result = await sut.GetBordersAsync(country.Id);
 
-        var sut = new CountriesProcess(countries.Object, geoBoundaries.Object);
-
-        var result = await sut.GetBordersAsync(1);
-
-        Assert.AreEqual(SampleGeoJson, result);
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Contains("FeatureCollection"));
     }
 
     [TestMethod]
     public async Task GetBordersAsync_ReturnsNull_WhenCountryHasNoIsoAlpha3()
     {
-        var countries = new Mock<ICountryBusiness>();
-        var geoBoundaries = new Mock<IGeoBoundariesService>();
+        await using var f = new Fixture();
+        var country = await f.AddCountryAsync(null);
+        var sut = f.Build(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
 
-        countries.Setup(c => c.GetIsoAlpha3Async(1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
-
-        var sut = new CountriesProcess(countries.Object, geoBoundaries.Object);
-
-        var result = await sut.GetBordersAsync(1);
+        var result = await sut.GetBordersAsync(country.Id);
 
         Assert.IsNull(result);
-        geoBoundaries.Verify(g => g.GetBordersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [TestMethod]
     public async Task GetBordersAsync_ReturnsNull_WhenGeoBoundariesReturnsNull()
     {
-        var countries = new Mock<ICountryBusiness>();
-        var geoBoundaries = new Mock<IGeoBoundariesService>();
+        await using var f = new Fixture();
+        var country = await f.AddCountryAsync("XA3");
+        var sut = f.Build(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
 
-        countries.Setup(c => c.GetIsoAlpha3Async(99, It.IsAny<CancellationToken>()))
-            .ReturnsAsync("ZZZ");
-        geoBoundaries.Setup(g => g.GetBordersAsync("ZZZ", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
-
-        var sut = new CountriesProcess(countries.Object, geoBoundaries.Object);
-
-        var result = await sut.GetBordersAsync(99);
+        var result = await sut.GetBordersAsync(country.Id);
 
         Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public async Task GetBordersAsync_ReturnsCachedGeoJson_WhenCacheHit()
+    {
+        await using var f = new Fixture();
+        var country = await f.AddCountryAsync("XA4");
+        f.TrackBlob("XA4.json");
+
+        // Pre-populate the cache
+        var cache = new BlobBorderCacheService(_blobClient);
+        await cache.SetAsync("XA4", SampleGeoJson);
+
+        // GeoBoundaries handler should not be called
+        var geoBoundariesCalled = false;
+        var sut = f.Build(_ => { geoBoundariesCalled = true; return new HttpResponseMessage(HttpStatusCode.NotFound); });
+
+        var result = await sut.GetBordersAsync(country.Id);
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.Contains("FeatureCollection"));
+        Assert.IsFalse(geoBoundariesCalled, "GeoBoundaries must not be called when cache is populated");
     }
 }


### PR DESCRIPTION
## Summary

- **RDP polygon simplification** — Ramer-Douglas-Peucker algorithm added to `GeoBoundariesService` to reduce collinear/near-collinear points from GeoJSON border polygons before serving to the frontend
- **Blob border cache** — `BlobBorderCacheService` (Azure Blob Storage) caches processed GeoJSON borders; `CountriesProcess.GetBordersAsync` reads cache-first, falls back to GeoBoundaries API, writes to cache; `SetAsync` errors are isolated (try/catch) so a cache write failure never breaks the border response
- **Architecture docs** — `architecture-callflow.html` and `architecture-diagram.html` updated to show the 6-step Get Borders flow with cache-first path

## PHASE1 review findings resolved

| Finding | Fix |
|---|---|
| PHASE1-ADV-001 — No test for RDP simplification | `GetBordersAsync_SimplifiesPolygon_WhenRingHasCollinearPoints` test added |
| PHASE1-ADV-002 — Cache `SetAsync` not error-isolated | Wrapped in `try/catch`; exception swallowed, response still returned |
| PHASE1-BLOCK-001 — Architecture diagrams not updated for cache-first flow | `architecture-callflow.html` + `architecture-diagram.html` updated in `a868b83` |

## Test plan

- [ ] 141/141 tests pass on this branch (verified locally)
- [ ] CountriesProcessTests: 5/5 pass with Azurite running (verified locally)
- [ ] Architecture diagrams reviewed for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)